### PR TITLE
fixed wrong usage of 'chunks' in gcm_send_bulk_message

### DIFF
--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -75,7 +75,7 @@ def gcm_send_bulk_message(registration_ids, data, collapse_key=None, delay_while
 	# GCM only allows up to 1000 reg ids per bulk message
 	# https://developer.android.com/google/gcm/gcm.html#request
 	max_recipients = SETTINGS.get("GCM_MAX_RECIPIENTS")
-	if len(registration_ids) > SETTINGS.get("GCM_MAX_RECIPIENTS"):
+	if len(registration_ids) > max_recipients:
 		ret = []
 		for chunk in chunks(registration_ids, max_recipients):
 			ret.append(gcm_send_bulk_message(chunk, data, collapse_key, delay_while_idle))


### PR DESCRIPTION
This PR fixes gcm_send_bulk_message for len(registration_ids) > SETTINGS.get("GCM_MAX_RECIPIENTS")
