### PR TITLE
Use bigint for db_type

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -42,9 +42,6 @@ class HexIntegerField(with_metaclass(models.SubfieldBase, models.BigIntegerField
 		else:
 			return super(HexIntegerField, self).db_type(connection)
 
-	def get_internal_type(self):
-		return self.__class__.__name__
-
 	def get_prep_value(self, value):
 		if value is None or value is "":
 			return None


### PR DESCRIPTION
The way this field inherits, it will try to use get_internal_type to return the db_type. Since django doesn't know what HexIntegerField is, it just returns none.

This causes the field to not be created in the db for syncdb.

This came up because we have south turned off for our tests.

I'm not sure if my solution is the correct one.
