### PR TITLE
use '==' for comparison against empty string instead of 'is'

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -46,7 +46,7 @@ class HexIntegerField(with_metaclass(models.SubfieldBase, models.BigIntegerField
 		return self.__class__.__name__
 
 	def get_prep_value(self, value):
-		if value is None or value is "":
+		if value is None or value == "":
 			return None
 		value = int(value, 16)
 		# on postgres only, interpret as signed


### PR DESCRIPTION
Using `is` matches not just the string value but also the type so it doesn't match a unicode empty string `u""`.
