### PR TITLE
The APNS push payload is not built properly

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -67,13 +67,13 @@ def _apns_send(token, alert, badge=0, sound="chime", content_available=False, ac
 		apns_data["alert"] = alert
 
 	if badge:
-		data["badge"] = badge
+		apns_data["badge"] = badge
 
 	if sound:
-		data["sound"] = sound
+		apns_data["sound"] = sound
 
 	if content_available:
-		data["content-available"] = 1
+		apns_data["content-available"] = 1
 
 	data["aps"] = apns_data
 	data.update(extra)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 from test_models import *
+from test_push_payload import *

--- a/tests/test_push_payload.py
+++ b/tests/test_push_payload.py
@@ -1,0 +1,12 @@
+import mock
+from django.test import TestCase
+from push_notifications.apns import _apns_send
+
+
+class PushPayloadTest(TestCase):
+    def test_push_payload(self):
+        socket = mock.MagicMock()
+        with mock.patch("push_notifications.apns._apns_pack_message") as p:
+            _apns_send('123', 'Hello world', badge=1, sound='chime', extra={"custom_data": 12345}, socket=socket)
+            p.assert_called_once_with('123', {'aps': {'alert': 'Hello world', 'badge': 1, 'sound': 'chime'},
+                                              "custom_data": 12345})


### PR DESCRIPTION
According to the [documentation](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html) the `badge`, `sound` and `content-available` keys should be in the `aps` dictionary.
