### PR TITLE
Fix APNS pack message call and improve payload data

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -55,7 +55,7 @@ def _apns_send(token, alert, badge=0, sound=None, content_available=False, actio
 	apns_data = {}
 
 	if action_loc_key or loc_key or loc_args:
-		alert = {"body": alert}
+		alert = {"body": alert} if alert else {}
 		if action_loc_key:
 			alert["action-loc-key"] = action_loc_key
 		if loc_key:

--- a/tests/test_push_payload.py
+++ b/tests/test_push_payload.py
@@ -10,3 +10,9 @@ class PushPayloadTest(TestCase):
             _apns_send('123', 'Hello world', badge=1, sound='chime', extra={"custom_data": 12345}, socket=socket)
             p.assert_called_once_with('123', '{"aps":{"sound":"chime","badge":1,"alert":"Hello world"},'
                                              '"custom_data":12345}')
+
+    def test_localised_push_with_empty_body(self):
+        socket = mock.MagicMock()
+        with mock.patch("push_notifications.apns._apns_pack_message") as p:
+            _apns_send('123', None, loc_key='TEST_LOC_KEY', socket=socket)
+            p.assert_called_once_with('123', '{"aps":{"alert":{"loc-key":"TEST_LOC_KEY"}}}')


### PR DESCRIPTION
`_apns_pack_message` was being called with a dictionary instead of a string which caused it to throw an exception. This PR fixes that.

Other small changes:
-change the default `sound` argument to None
-remove alert `body` key when sending a push with localised data  
