### PR TITLE
Allow optional data params on GCM messages; Send single message as Json;

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,15 +68,24 @@ For APNS, you are required to include APNS_CERTIFICATE.
 
 Sending messages
 ----------------
+GCM and APNS services have slight different semantics. The app tries to offer a common interface for both when using the models.
+
 ::
 
 	from push_notifications.models import APNSDevice, GCMDevice
 
 	device = GCMDevice.objects.get(registration_id=gcm_reg_id)
-	device.send_message({"foo": "bar"}) # The message will be sent and received as json.
+	# The first argument will be sent as "message" to the intent extras Bundle
+	# Retrieve it with intent.getExtras().getString("message")
+	device.send_message("You've got mail")
+	# If you want to customize, send an extra dict and a None message.
+	# the extras dict will be maped into the intent extras Bundle. Remember, GCM converts everything to strings!
+	device.send_message(None, extra={"foo": "bar"}')
 
 	device = APNSDevice.objects.get(registration_id=apns_token)
-	device.send_message("You've got mail") # The message may only be sent as text.
+	device.send_message("You've got mail") # Alert message may only be sent as text.
+	device.send_message(None, badge=5) # No alerts but with badge.
+	device.send_message(None, badge=1, extra={"foo": "bar"}) # Silent message with badge and added custom data.
 
 Note that APNS does not support sending payloads that exceed 256 bytes. The message is only one part of the payload, if
 once constructed the payload exceeds the maximum size, an APNSDataOverflow exception will be raised before anything is sent.
@@ -93,7 +102,6 @@ Sending messages in bulk
 
 Sending messages in bulk makes use of the bulk mechanics offered by GCM and APNS. It is almost always preferable to send
 bulk notifications instead of single ones.
-Note that in GCM, the device will receive data in a different format depending on whether it's been sent in bulk or not.
 
 
 Exceptions

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -28,14 +28,15 @@ class GCMDeviceManager(models.Manager):
 
 
 class GCMDeviceQuerySet(models.query.QuerySet):
-	def send_message(self, message):
+	def send_message(self, message, **kwargs):
 		if self:
 			from .gcm import gcm_send_bulk_message
+			data = kwargs.pop("extra", {})
+			if message is not None:
+				data["message"] = message
 			return gcm_send_bulk_message(
 				registration_ids=list(self.values_list("registration_id", flat=True)),
-				data={"message": message},
-				collapse_key="message"
-			)
+				data=data)
 
 
 class GCMDevice(Device):
@@ -51,9 +52,12 @@ class GCMDevice(Device):
 	class Meta:
 		verbose_name = _("GCM device")
 
-	def send_message(self, message):
+	def send_message(self, message, **kwargs):
 		from .gcm import gcm_send_message
-		return gcm_send_message(registration_id=self.registration_id, data={"message": message}, collapse_key="message")
+		data = kwargs.pop("extra", {})
+		if message is not None:
+			data["message"] = message
+		return gcm_send_message(registration_id=self.registration_id, data=data, **kwargs)
 
 
 class APNSDeviceManager(models.Manager):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 from test_models import *
-from test_push_payload import *
+from test_gcm_push_payload import *
+from test_apns_push_payload import *

--- a/tests/test_apns_push_payload.py
+++ b/tests/test_apns_push_payload.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from push_notifications.apns import _apns_send
 
 
-class PushPayloadTest(TestCase):
+class APNSPushPayloadTest(TestCase):
     def test_push_payload(self):
         socket = mock.MagicMock()
         with mock.patch("push_notifications.apns._apns_pack_message") as p:
@@ -16,3 +16,9 @@ class PushPayloadTest(TestCase):
         with mock.patch("push_notifications.apns._apns_pack_message") as p:
             _apns_send('123', None, loc_key='TEST_LOC_KEY', socket=socket)
             p.assert_called_once_with('123', '{"aps":{"alert":{"loc-key":"TEST_LOC_KEY"}}}')
+
+    def test_using_extra(self):
+        socket = mock.MagicMock()
+        with mock.patch("push_notifications.apns._apns_pack_message") as p:
+            _apns_send('123', 'sample', extra={"foo": "bar"}, socket=socket)
+            p.assert_called_once_with('123', '{"aps":{"alert":"sample"},"foo":"bar"}')

--- a/tests/test_gcm_push_payload.py
+++ b/tests/test_gcm_push_payload.py
@@ -1,0 +1,19 @@
+import mock
+from django.test import TestCase
+from push_notifications.gcm import gcm_send_message, gcm_send_bulk_message
+
+
+class GCMPushPayloadTest(TestCase):
+	def test_push_payload(self):
+		with mock.patch("push_notifications.gcm._gcm_send") as p:
+			gcm_send_message("abc", {'message': 'Hello world'})
+			p.assert_called_once_with(
+				'registration_id=abc&data.message=Hello+world',
+				'application/x-www-form-urlencoded;charset=UTF-8')
+
+	def test_bulk_push_payload(self):
+		with mock.patch("push_notifications.gcm._gcm_send") as p:
+			gcm_send_bulk_message(["abc", "123"], {'message': 'Hello world'})
+			p.assert_called_once_with(
+				'{"data":{"message":"Hello world"},"registration_ids":["abc","123"]}',
+				'application/json')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+import mock
 from django.test import TestCase
 from push_notifications.models import GCMDevice, APNSDevice
 
@@ -14,3 +15,41 @@ class ModelTestCase(TestCase):
 			registration_id="a valid registration id",
 		)
 		assert device.id is not None
+
+	def test_gcm_send_message(self):
+		device = GCMDevice.objects.create(
+			registration_id="abc",
+		)
+		with mock.patch("push_notifications.gcm._gcm_send") as p:
+			device.send_message("Hello world")
+			p.assert_called_once_with(
+				'registration_id=abc&data.message=Hello+world',
+				'application/x-www-form-urlencoded;charset=UTF-8')
+
+	def test_gcm_send_message_extra(self):
+		device = GCMDevice.objects.create(
+			registration_id="abc",
+		)
+		with mock.patch("push_notifications.gcm._gcm_send") as p:
+			device.send_message("Hello world", extra={"foo": "bar"})
+			p.assert_called_once_with(
+				'registration_id=abc&data.foo=bar&data.message=Hello+world',
+				'application/x-www-form-urlencoded;charset=UTF-8')
+
+	def test_apns_send_message(self):
+		device = APNSDevice.objects.create(
+			registration_id="abc",
+		)
+		socket = mock.MagicMock()
+		with mock.patch("push_notifications.apns._apns_pack_message") as p:
+			device.send_message("Hello world", socket=socket)
+			p.assert_called_once_with('abc', '{"aps":{"alert":"Hello world"}}')
+
+	def test_apns_send_message_extra(self):
+		device = APNSDevice.objects.create(
+			registration_id="abc",
+		)
+		socket = mock.MagicMock()
+		with mock.patch("push_notifications.apns._apns_pack_message") as p:
+			device.send_message("Hello world", extra={"foo": "bar"}, socket=socket)
+			p.assert_called_once_with('abc', '{"aps":{"alert":"Hello world"},"foo":"bar"}')


### PR DESCRIPTION
Allow optional data params on GCM messages so Android app sees the optional data in the Bundle.
Also send single messages as json since it's slight safer as far as putting unknown types in the data dict. Another benefit is the code reuse. 
