### PR TITLE
Fix the travis build badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 django-push-notifications
 =========================
 
-.. image:: https://api.travis-ci.org/Adys/django-push-notifications.png
-	:target: https://travis-ci.org/Adys/django-push-notifications
+.. image:: https://api.travis-ci.org/jleclanche/django-push-notifications.png
+	:target: https://travis-ci.org/jleclanche/django-push-notifications
 
 A minimal Django app that implements Device models that can send messages through APNS and GCM.
 


### PR DESCRIPTION
Hi, I just noticed the travis build badge was pointing to another user, this updates the badge to point to your Travis page.
