### PR TITLE
check string length, not dict length

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -81,7 +81,7 @@ def _apns_send(token, alert, badge=0, sound=None, content_available=False, actio
 	# convert to json, avoiding unnecessary whitespace with separators
 	json_data = json.dumps(data, separators=(",", ":"))
 
-	if len(data) > APNS_MAX_NOTIFICATION_SIZE:
+	if len(json_data) > APNS_MAX_NOTIFICATION_SIZE:
 		raise APNSDataOverflow("Notification body cannot exceed %i bytes" % (APNS_MAX_NOTIFICATION_SIZE))
 
 	data = _apns_pack_message(token, json_data)

--- a/tests/test_apns_push_payload.py
+++ b/tests/test_apns_push_payload.py
@@ -1,6 +1,6 @@
 import mock
 from django.test import TestCase
-from push_notifications.apns import _apns_send
+from push_notifications.apns import _apns_send, APNSDataOverflow
 
 
 class APNSPushPayloadTest(TestCase):
@@ -22,3 +22,9 @@ class APNSPushPayloadTest(TestCase):
         with mock.patch("push_notifications.apns._apns_pack_message") as p:
             _apns_send('123', 'sample', extra={"foo": "bar"}, socket=socket)
             p.assert_called_once_with('123', '{"aps":{"alert":"sample"},"foo":"bar"}')
+
+    def test_oversized_payload(self):
+        socket = mock.MagicMock()
+        with mock.patch("push_notifications.apns._apns_pack_message") as p:
+            self.assertRaises(APNSDataOverflow, _apns_send, '123', '_' * 257, socket=socket)
+            p.assert_has_calls([])


### PR DESCRIPTION
`_apns_send` wasn't properly checking the length of the payload. I think this fixes it. I added a test for this that fails without the change, but succeeds with the change.
