### PR TITLE
Allow sending empty sound push

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ v1.1.0 (2014-05-xx)
 * Added a date_created field to GCMDevice and APNSDevice. This field keeps track of when the Device was created.
   This requires a `manage.py migrate`.
 * Updated APNS protocol support
+* Allow sending empty sounds on APNS
 * Several APNS bugfixes
 * Assorted migrations bugfixes
 * Added a test suite

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -114,7 +114,7 @@ def _apns_send(token, alert, badge=0, sound=None, content_available=False, actio
 	if badge:
 		aps_data["badge"] = badge
 
-	if sound:
+	if sound is not None:
 		aps_data["sound"] = sound
 
 	if content_available:


### PR DESCRIPTION
This is useful for fixing an [iOS bug](http://stackoverflow.com/a/19427960/536113) regarding silent pushes.
