### PR TITLE
Add logging capabilities to _apns_send

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -127,8 +127,8 @@ def _apns_send(token, alert, badge=0, sound=None, content_available=False, actio
 	json_data = json.dumps(data, separators=(",", ":"))
 
 	if(logger is not None):
-		logger.info(json_data)
-		
+		logger.debug(json_data)
+
 	if len(json_data) > APNS_MAX_NOTIFICATION_SIZE:
 		raise APNSDataOverflow("Notification body cannot exceed %i bytes" % (APNS_MAX_NOTIFICATION_SIZE))
 


### PR DESCRIPTION
Sometimes it is useful to know what is the message effectively being sent to APNS for debug purposes.

Adding a logger parameter that takes a regular Django Logger to the _apns_send method of apns.py enables this logging capability.

This change would not affect existing code and devs wanting to get this information could have it by adding the logger parameter to the send_message methods.
