### PR TITLE
added zip_safe=False to fix issues with south like in tastiepie

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,5 @@ setup(
 	long_description=README,
 	url="https://github.com/jleclanche/django-push-notifications",
 	version=push_notifications.__version__,
+	zip_safe=False,
 )


### PR DESCRIPTION
South throws an error in some cases. Adding zip_safe=False fixes that as described in
https://github.com/toastdriven/django-tastypie/issues/449

It fixed the issue for me, maybe you want to merge it
