### PR TITLE
fix `HexIntegerField.get_prep_value` when value is already a string

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -53,7 +53,8 @@ class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerF
 	def get_prep_value(self, value):
 		if value is None or value == "":
 			return None
-		value = int(value, 16)
+		if isinstance(value, six.string_types):
+			value = int(value, 16)
 		# on postgres only, interpret as signed
 		if connection.settings_dict["ENGINE"] in postgres_engines:
 			value = struct.unpack("q", struct.pack("Q", value))[0]


### PR DESCRIPTION
value may already be an integer so trying to create a base 16 int from
it fails
