### PR TITLE
apns broken pipe verification

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -8,7 +8,9 @@ import json
 import ssl
 import struct
 import socket
+import socket as Socket
 import time
+import errno
 from contextlib import closing
 from binascii import unhexlify
 from django.core.exceptions import ImproperlyConfigured
@@ -145,7 +147,12 @@ def _apns_send(token, alert, badge=None, sound=None, category=None, content_avai
 	frame = _apns_pack_frame(token, json_data, identifier, expiration_time, priority)
 
 	if socket:
-		socket.write(frame)
+		try:
+			socket.write(frame)
+                except Socket.error, e:
+                        if e[0] == errno.EPIPE:
+                                raise APNSServerError(20, identifier)
+                        raise APNSServerError(255, identifier)
 	else:
 		with closing(_apns_create_socket_to_push()) as socket:
 			socket.write(frame)


### PR DESCRIPTION
In my production test I got disconnect from Apple server when some of my token is invalid.
Because this premature disconnection I cannot get the identifier to handle the bad token.
I added some verification to handle that.
