### PR TITLE
restore error checking on apns.apns_send_bulk_message

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -218,6 +218,7 @@ def apns_send_bulk_message(registration_ids, alert, **kwargs):
 	with closing(_apns_create_socket_to_push()) as socket:
 		for identifier, registration_id in enumerate(registration_ids):
 			_apns_send(registration_id, alert, identifier=identifier, socket=socket, **kwargs)
+		_apns_check_errors(socket)
 
 
 def apns_fetch_inactive_ids():


### PR DESCRIPTION
Since I'm passing my own socket I should be responsible for checking errors on it. _send only check for error if it creates a new socket.

Thanks @evdoks

Reverse regression introduced on a5452babd905acb6c1d0029c2201b5eae3ca1059
