### PR TITLE
Add instructions for APNS pem cert generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -328,13 +328,10 @@ The flow is similar for development and production environments. These steps are
 **Step 5** Check certificate validity and connectivity to APNS
 
 .. code-block:: bash
-	$ openssl s_client -connect <gateway> -cert aps-cert.pem -key aps-key-noenc.pem
 
-Substitute a `gateway` value into the above command depending on whether you're testing
-a development or production certificate:
-
-- development: `gateway.sandbox.push.apple.com:2195`
-- production: `gateway.push.apple.com:2195`
+	$ openssl s_client -connect gateway.push.apple.com:2195 -cert aps-cert.pem -key aps-key-noenc.pem
 
 If the certificate and key are valid, the connection will open and remain open. If it is not
 the connection will be closed and an error potentially displayed.
+
+To test if the certificate works in sandbox mode, simply replace the `gateway` with `gateway.sandbox.push.apple.com:2195`.

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Edit your settings.py file:
 	If you are planning on running your project with ``APNS_USE_SANDBOX=True``, then make sure you have set the
 	*development* certificate as your ``APNS_CERTIFICATE``. Otherwise the app will not be able to connect to the correct host. See settings_ for details.
 
-You can learn more about APNS certificates `here <https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html>`_.
+Read more about `Generation of an APNS PEM file`_.
 
 Native Django migrations are in use. ``manage.py migrate`` will install and migrate all models.
 
@@ -71,7 +71,7 @@ For WNS, you need both the ``WNS_PACKAGE_SECURITY_KEY`` and the ``WNS_SECRET_KEY
 
 **APNS settings**
 
-- ``APNS_CERTIFICATE``: Absolute path to your APNS certificate file. Certificates with passphrases are not supported.
+- ``APNS_CERTIFICATE``: Absolute path to your APNS certificate file. Certificates with passphrases are not supported. Read more about `Generation of an APNS PEM file`_.
 - ``APNS_TOPIC``: The topic of the remote notification, which is typically the bundle ID for your app. If you omit this header and your APNs certificate does not specify multiple topics, the APNs server uses the certificate’s Subject as the default topic.
 - ``APNS_USE_ALTERNATIVE_PORT``: Use port 2197 for APNS, instead of default port 443.
 - ``APNS_USE_SANDBOX``: Use 'api.development.push.apple.com', instead of default host 'api.push.apple.com'.
@@ -276,3 +276,65 @@ The ``UPDATE_ON_DUPLICATE_REG_ID`` only works with DRF.
 
 
 .. [1] Any devices which are not selected, but are not receiving notifications will not be deactivated on a subsequent call to "prune devices" unless another attempt to send a message to the device fails after the call to the feedback service.
+
+Generation of an APNS PEM file
+------------------------------
+
+The ``APNS_CERTIFICATE`` setting must reference the location of a PEM file. This file must
+contain a certificate and private key pair allowing a secure connection to Apple's push gateway.
+
+These instructions assume the use of Mac OS X.
+
+There are two main steps involved; generating the certificate, then conversion of this certificate into `PEM` format for use with this library.
+
+**Generating the push certificate**
+
+Using `Apple's Developer site <https://developer.apple.com/account>`_ you need to generate a push notification certificate for either development or production. There are countless instructions online and Apple change their flow for this regularly, so it is not documented here. The end result should be an exported certificate and private key with the `p12` extension.
+
+When initiating the certificate generation flow in Apple's Dev site, do this from within the specific app's configuration:
+
+	Identifiers -> App IDs -> [Your App] -> Edit -> Push Notifications Section (Create Certificate) .
+
+If you initiate this flow from the top level `Certificates` section, the resulting export may contain both sandbox and production certificates and keys, which confuses matters a lot.
+
+**Converting the certificate to `PEM` format**
+
+The flow is similar for development and production environments. These steps are adapted from `a Stack Overflow post <https://stackoverflow.com/a/27942504/4664727>`_.
+
+**Step 1:** Create Certificate .pem from Certificate .p12
+
+.. code-block:: bash
+
+    $ openssl pkcs12 -clcerts -nokeys -out aps-cert.pem -in Certificates.p12
+
+**Step 2** Create Key .pem from Key .p12
+
+.. code-block:: bash
+
+	$ openssl pkcs12 -nocerts -out aps-key.pem -in Certificates.p12
+
+**Step 3** Remove pass phrase on the key
+
+.. code-block:: bash
+
+	$ openssl rsa -in aps-key.pem -out aps-key-noenc.pem
+
+**Step 4** Combine the two into one file
+
+.. code-block:: bash
+
+	$ cat aps-cert.pem aps-key-noenc.pem > aps.pem
+
+**Step 5** Check certificate validity and connectivity to APNS
+
+.. code-block:: bash
+	$ openssl s_client -connect <gateway> -cert aps-cert.pem -key aps-key-noenc.pem
+
+Substitute a `gateway` value into the above command depending on whether you're testing
+a development or production certificate:
+
+- development: `gateway.sandbox.push.apple.com:2195`
+- production: `gateway.push.apple.com:2195`
+
+If the certificate and key are valid, the connection will open and remain open. If it is not
+the connection will be closed and an error potentially displayed.


### PR DESCRIPTION
Each time I need to renew certificates or setup a new project I waste time
fighting with Apple generating a certificate then digging around for decent
instructions for converting that exported certificate to a usable PEM format.

I'd like to begin documenting a sensible, repeatable method for at least the
conversion here.