### PR TITLE
Support `apns-collapse-id` via `collapse_id` kwarg

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -78,6 +78,8 @@ def _apns_send(
 		except ValueError:
 			raise APNSUnsupportedPriority("Unsupported priority %d" % (priority))
 
+	notification_kwargs["collapse_id"] = kwargs.pop("collapse_id", None)
+
 	if batch:
 		data = [apns2_client.Notification(
 			token=rid, payload=_apns_prepare(rid, alert, **kwargs)) for rid in registration_id]

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
 	pytest
 	pytest-django
 	mock
+	pywebpush
 	djangorestframework>=3.5
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1


### PR DESCRIPTION
Re #429 

This would appear to work but hasn't been tested. I can't figure out how to run existing tests. :upside_down_face: 