### PR TITLE
WIP: Do not grab FCM notification keys from `extra` kwargs

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -79,6 +79,8 @@ def _apns_send(
 		except ValueError:
 			raise APNSUnsupportedPriority("Unsupported priority %d" % (priority))
 
+	notification_kwargs["collapse_id"] = kwargs.pop("collapse_id", None)
+
 	if batch:
 		data = [apns2_client.Notification(
 			token=rid, payload=_apns_prepare(rid, alert, **kwargs)) for rid in registration_id]

--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -131,9 +131,6 @@ def _cm_send_request(
 			notification_payload["body"] = data.pop("message", None)
 
 		for key in FCM_NOTIFICATIONS_PAYLOAD_KEYS:
-			value_from_extra = data.pop(key, None)
-			if value_from_extra:
-				notification_payload[key] = value_from_extra
 			value_from_kwargs = kwargs.pop(key, None)
 			if value_from_kwargs:
 				notification_payload[key] = value_from_kwargs

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,6 @@
 from setuptools import setup
 
 
-setup()
+setup(
+    name="django-push-notifications"
+)


### PR DESCRIPTION
Currently: As a convenience, it appears that this package will grab keys and values from the `extra` dict that normally belong in the FCM `notification` payload.

Problem: Some android app frameworks (namely phonegap/cordova) require that you send the notification data inside the extra data payload and not the main notification payload (see https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#notification-vs-data-payloads). The existing code prevents sending keys such as `title` and `body` in that additional data payload. 

Suggested Change: Simply omit pulling the reserved keywords from the `extra` dict.

I have no yet updated the tests to reflect the change in behavior because I wanted to see if this was an acceptable change or not. 