### PR TITLE
Fix APN bulk messages

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -51,8 +51,8 @@ def _apns_prepare(
 		else:
 			apns2_alert = alert
 
-			if callable(badge):
-				badge = badge(token)
+		if callable(badge):
+			badge = badge(token)
 
 		return apns2_payload.Payload(
 			apns2_alert, badge, sound, content_available, mutable_content, category,


### PR DESCRIPTION
APN bulk message fail when sent with localized keys and badge function. It results in a TypeError as the lambda function is not JSON serializable.