### PR TITLE
Avoid mutating arguments in `gcm._cm_send_request`

### DIFF
--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -124,10 +124,10 @@ def _cm_send_request(
 	if cloud_type == "FCM" and use_fcm_notifications:
 		notification_payload = {}
 		if "message" in data:
-			notification_payload["body"] = data.pop("message", None)
+			notification_payload["body"] = data["message"]
 
 		for key in FCM_NOTIFICATIONS_PAYLOAD_KEYS:
-			value_from_extra = data.pop(key, None)
+			value_from_extra = data.get(key, None)
 			if value_from_extra:
 				notification_payload[key] = value_from_extra
 			value_from_kwargs = kwargs.pop(key, None)


### PR DESCRIPTION
`gcm._cm_send_request` mutates its `data` argument by using `dict.pop`. Since this function may be called more than once from `push_notifications.GCMDeviceQuerySet.send_message`, with same dict as `data` argument, only the first call will receive proper values.