### PR TITLE
Fix gcm mutating extra args

### DIFF
--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -119,6 +119,8 @@ def _cm_send_request(
 
 	payload = {"registration_ids": registration_ids} if registration_ids else {}
 
+	data = data.copy()
+
 	# If using FCM, optionnally autodiscovers notification related keys
 	# https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages
 	if cloud_type == "FCM" and use_fcm_notifications:


### PR DESCRIPTION
`gcm._cm_send_request` mutates its `data` argument by calling `dict.pop` for all items in `FCM_NOTIFICATIONS_PAYLOAD_KEYS` and then using the rest as `payload["data"]`. However, since this function may be called more than once from `push_notifications.GCMDeviceQuerySet.send_message`, with same dict as `data` argument, only the first call will have extra values in `payload["notification"]`.

Suggested fix creates a copy of the argument before mutating it. A test case that reproduces the error if ran without the fix is also included.