### PR TITLE
 Added FCM channels support for custom notification sound on Android Oreo 

### DIFF
--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -26,7 +26,7 @@ FCM_OPTIONS_KEYS = [
 ]
 FCM_NOTIFICATIONS_PAYLOAD_KEYS = [
 	"title", "body", "icon", "sound", "badge", "color", "tag", "click_action",
-	"body_loc_key", "body_loc_args", "title_loc_key", "title_loc_args"
+	"body_loc_key", "body_loc_args", "title_loc_key", "title_loc_args", "android_channel_id"
 ]
 
 


### PR DESCRIPTION
Added "android_channel_id" notification parameter as per doc (https://firebase.google.com/docs/cloud-messaging/http-server-ref) in order to enable custom notification sound on Android Oreo devices.