### PR TITLE
Add support for python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 	Programming Language :: Python :: 3.4
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
 	Topic :: Internet :: WWW/HTTP
 	Topic :: System :: Networking
 


### PR DESCRIPTION
Hi

Without this it is impossible to install using pip when running python 3.7.