### PR TITLE
Fix problems with CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,16 @@
 sudo: false
 language: python
 python: "3.6"
+dist: xenial
 
 env:
   - TOXENV=py27-django111
-  - TOXENV=py34-django111
   - TOXENV=py36-django111
   - TOXENV=py36-django20
   - TOXENV=py36-djangomaster
+  - TOXENV=py37-django111
+  - TOXENV=py37-django20
+  - TOXENV=py37-djangomaster
   - TOXENV=flake8
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 # https://travis-ci.org/jazzband/django-push-notifications
 sudo: false
 language: python
-python: "3.6"
+python: "3.7"
 dist: xenial
 
 env:
   - TOXENV=py27-django111
-  - TOXENV=py36-django111
-  - TOXENV=py36-django20
-  - TOXENV=py36-djangomaster
   - TOXENV=py37-django111
   - TOXENV=py37-django20
-  - TOXENV=py37-djangomaster
+  - TOXENV=py37-django22
   - TOXENV=flake8
 
 cache:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 django-push-notifications
 =========================
-.. image:: https://api.travis-ci.org/jazzband/django-push-notifications.png
+.. image:: https://travis-ci.org/jazzband/django-push-notifications.svg?branch=master
 	:target: https://travis-ci.org/jazzband/django-push-notifications
 
 .. image:: https://jazzband.co/static/img/badge.svg

--- a/push_notifications/conf/__init__.py
+++ b/push_notifications/conf/__init__.py
@@ -1,8 +1,9 @@
 from django.utils.module_loading import import_string
+
 from .app import AppConfig  # noqa: F401
 from .appmodel import AppModelConfig  # noqa: F401
 from .legacy import LegacyConfig  # noqa: F401
-from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS  # noqa: I001
 
 
 manager = None

--- a/push_notifications/conf/legacy.py
+++ b/push_notifications/conf/legacy.py
@@ -32,20 +32,20 @@ class LegacyConfig(BaseConfig):
 
 	def get_gcm_api_key(self, application_id=None):
 		msg = (
-			"Set PUSH_NOTIFICATIONS_SETTINGS[\"GCM_API_KEY\"] to send messages through GCM."
+			'Set PUSH_NOTIFICATIONS_SETTINGS["GCM_API_KEY"] to send messages through GCM.'
 		)
 		return self._get_application_settings(application_id, "GCM_API_KEY", msg)
 
 	def get_fcm_api_key(self, application_id=None):
 		msg = (
-			"Set PUSH_NOTIFICATIONS_SETTINGS[\"FCM_API_KEY\"] to send messages through FCM."
+			'Set PUSH_NOTIFICATIONS_SETTINGS["FCM_API_KEY"] to send messages through FCM.'
 		)
 		return self._get_application_settings(application_id, "FCM_API_KEY", msg)
 
 	def get_post_url(self, cloud_type, application_id=None):
 		key = "{}_POST_URL".format(cloud_type)
 		msg = (
-			"Set PUSH_NOTIFICATIONS_SETTINGS[\"{}\"] to send messages through {}.".format(
+			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through {}.'.format(
 				key, cloud_type
 			)
 		)
@@ -54,7 +54,7 @@ class LegacyConfig(BaseConfig):
 	def get_error_timeout(self, cloud_type, application_id=None):
 		key = "{}_ERROR_TIMEOUT".format(cloud_type)
 		msg = (
-			"Set PUSH_NOTIFICATIONS_SETTINGS[\"{}\"] to send messages through {}.".format(
+			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through {}.'.format(
 				key, cloud_type
 			)
 		)
@@ -63,7 +63,7 @@ class LegacyConfig(BaseConfig):
 	def get_max_recipients(self, cloud_type, application_id=None):
 		key = "{}_MAX_RECIPIENTS".format(cloud_type)
 		msg = (
-			"Set PUSH_NOTIFICATIONS_SETTINGS[\"{}\"] to send messages through {}.".format(
+			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through {}.'.format(
 				key, cloud_type
 			)
 		)

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -47,9 +47,9 @@ class Device(models.Model):
 
 	def __str__(self):
 		return (
-			self.name
-			or str(self.device_id or "")
-			or "%s for %s" % (self.__class__.__name__, self.user or "unknown user")
+			self.name or
+			str(self.device_id or "") or
+			"%s for %s" % (self.__class__.__name__, self.user or "unknown user")
 		)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
 [testenv:flake8]
 commands = flake8
 deps =
-	flake8
+	flake8==3.5.0
 	flake8-isort
 	flake8-quotes
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
 	py27-django111
-	py36-django{111,20,master}
+	py37-django{111,20,22}
 	flake8
 
 [testenv]
@@ -17,7 +17,7 @@ deps =
 	djangorestframework>=3.5
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
-	djangomaster: https://github.com/django/django/archive/master.tar.gz
+	django22: Django>=2.2
     apns2>=0.3.0
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
 	py27-django111
-	py34-django{111}
 	py36-django{111,20,master}
 	flake8
 


### PR DESCRIPTION
- Pin flake8 (can be updated later)
- Stop running tests on 3.4 & 3.6, and use 3.7 instead (xenial in travis isn't a fan of multiple pytrhon versions with tox)
- Run against Django 2.2 instead of master. Master is `3.0.0-alpha.0`, and not stable for our use