### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-## 1.7.0 (unreleased)
+## 2.0.0 (unreleased)
 * BACKWARDS-INCOMPATIBLE: Drop support for Django Rest Framework < 3.7
+* BACKWARDS-INCOMPATIBLE: NotificationError is now moved from `__init__.py` to `exceptions.py`
+    * Import with `from push_notifications.exceptions import NotificationError`
+* PYTHON: Add support for Python 3.7
+* APNS: Drop apns_errors, use exception class name instead
+* FCM: Add FCM channels support for custom notification sound on Android Oreo
+* BUGFIX: Fix error when send a message and the device is not active
+* BUGFIX: Fix error when APN bulk messages sent with localized keys and badge function
 
 
 ## 1.6.0 (2018-01-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * FCM: Add FCM channels support for custom notification sound on Android Oreo
 * BUGFIX: Fix error when send a message and the device is not active
 * BUGFIX: Fix error when APN bulk messages sent with localized keys and badge function
+* BUGFIX: Fix `Push failed: 403 fobidden` error when sending message to Chrome WebPushDevice
 
 
 ## 1.6.0 (2018-01-31)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-push-notifications
-version = 1.6.0
+version = 2.0.0
 description = Send push notifications to mobile devices through GCM, APNS or WNS and to WebPush (Chrome, Firefox and Opera) in Django
 author = Jerome Leclanche
 author_email = jerome@leclan.ch


### PR DESCRIPTION
We should probably write a bit more in the changelog before merging! Feel free to create a PR to this branch, `release-v1.7.0`, or push your commits if you are a part of jazzband, or just comment.. :smile: 

Commits since last release:
```
* 455a027 (HEAD -> release-v1.7.0, upstream/release-v1.7.0, v1.7.0) Release 1.7.0
* 2ce2837 (upstream/master) Add support for python 3.7 (#492)
* a73253a Fix problems with CI (#501)
* c4a0d71 README: Update APNs link
* 9182958 flake8: Ignore E503 (use Black style)
* 4962944  Add FCM channels support for custom notification sound on Android Oreo
* 45f0e96 Fix APN bulk messages
* 6f7b80d Avoid mutating arguments in `gcm._cm_send_request`
* e335ac6 Fix error when send a message and the device is not active
* 600495b gcm: Simplify some code
* 8c73a77 Fix README missing paragraph break confusion
* 1be2f2a Add Jazzband contributing guidelines
* 2ae27f9 Update repository URLs (again)
* 5954578 Cleanup overzealous tests
* 9f71624 Move Python 2 compatibility imports to push_notifications.compat
* 3052927 Update setup.cfg and DRF support notice
* c821ec9 Convert changelog to Markdown
* 86409f6 Move AUTHORS to ACKNOWLEDGEMENTS.md
* 803caa9 Clean up code style issues
* f625921 Move base NotificationError to push_notifications.exceptions
* c4785a3 Drop apns_errors, use exception class name instead
* a3bda0a Clean up imports and switch to isort+flake8-isort
* cee4160 (tag: 1.6.0) Release 1.6.0
```

Because of the breaking changes, we will bump to version `2.0.0`.