### PR TITLE
Solve `Push failed: 403 Forbidden` problem with Chrome

### DIFF
--- a/push_notifications/webpush.py
+++ b/push_notifications/webpush.py
@@ -29,7 +29,7 @@ def webpush_send_message(
 			subscription_info=subscription_info,
 			data=message,
 			vapid_private_key=get_manager().get_wp_private_key(application_id),
-			vapid_claims=get_manager().get_wp_claims(application_id),
+			vapid_claims=get_manager().get_wp_claims(application_id).copy(),
 			**kwargs
 		)
 		results = {"results": [{}]}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,4 +25,6 @@ ROOT_URLCONF = "core.urls"
 
 SECRET_KEY = "foobar"
 
-PUSH_NOTIFICATIONS_SETTINGS = {}
+PUSH_NOTIFICATIONS_SETTINGS = {
+	"WP_CLAIMS": {"sub": "mailto: jazzband@example.com"}
+}

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -1,7 +1,8 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
-from push_notifications.conf import LegacyConfig
+from push_notifications.conf import LegacyConfig, get_manager
+from push_notifications.webpush import WebPushError, webpush_send_message
 
 
 class LegacyConfigTestCase(TestCase):
@@ -34,3 +35,12 @@ class LegacyConfigTestCase(TestCase):
 			"LegacySettings does not support application_id. To enable multiple"
 			" application support, use push_notifications.conf.AppSettings."
 		)
+
+	def test_immutable_wp_claims(self):
+		vapid_claims_pre = get_manager().get_wp_claims(None).copy()
+		try:
+			webpush_send_message("", {}, "CHROME", "", "")
+		except WebPushError:
+			pass
+		vapid_claims_after = get_manager().get_wp_claims(None)
+		self.assertDictEqual(vapid_claims_pre, vapid_claims_after)


### PR DESCRIPTION
Hi,
there was a hidden problem occur frequently when sending notification to WebPushDevice specially with Google Chrome! when you have several devices say some firefox and some chrome, if first notification sent to chrome device, there will no bug, but if the first notification sent to firefox device sending to any of chrome devices will fail. I have search the web but no clear solution for it found out there, that lead me to guess it is a library bug. I found that you pass settings.PUSH_NOTIFICATIONS_SETTINGS['WP_CLAIMS'] via `LegacyConfig` to `pywebpush.webpush`. the `webpush` method alter given vapid_claims and inject `aud`, `exp` into it **once**.
It is a bad practice to change such settings in this way at runtime. It also lead to a hidden bug that if first device is firefox, its `aud` will be firefox related url, and when sending to chrome device after that, it will rejected with `Push failed: 403 Forbidden`.

I try to solve this problem with minimum change to code. and hope you merge it as soon as possible. thanks.
