### PR TITLE
Update supported version of apns2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-	apns2>=0.3.0
+	apns2>=0.3.0,<0.6.0
 	pywebpush>=1.3.0
 	Django>=1.11
 


### PR DESCRIPTION
There are some breaking changes in `apns2===0.6.0`, so we have to limit the supported version. They also introduced typings, essentially dropping support for python 3.4 (that we support).

Fixes #513 

I think this, together with the fix to add support for python 3.7, should be cherry-picked into a new release `1.6.1`
