### PR TITLE
Release 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,36 @@
 # https://travis-ci.org/jleclanche/django-push-notifications
 sudo: false
 language: python
-python: "3.6"
-
-env:
-  - TOXENV=py27-django111
-  - TOXENV=py34-django111
-  - TOXENV=py36-django111
-  - TOXENV=py36-django20
-  - TOXENV=py36-djangomaster
-  - TOXENV=flake8
-
-cache:
-  directories:
-    - $HOME/.cache/pip
-    - $TRAVIS_BUILD_DIR/.tox
-
-install:
-  - pip install tox
-
-script:
-  - tox
-
+python:
+- 2.7
+- 3.4
+- 3.6
+cache: pip
+dist: xenial
+install: travis_retry pip install tox-travis
+script: tox
+stages:
+- test
+- name: deploy
+  if: repo = jazzband/django-push-notifications AND tag IS present
+jobs:
+  include:
+  - stage: test
+  - stage: deploy
+    install: skip
+    script: skip
+    python: 3.6
+    env: skip
+    deploy:
+      provider: pypi
+      user: jazzband
+      server: https://jazzband.co/projects/django-push-notifications/upload
+      distributions: sdist bdist_wheel
+      password:
+        secure: ICRZGeqLWsqEtg9Iz62SHGOktUQEN+8h4wp0RKJJhcPIj59aKJNV+ET1wM+Xsh6OgpX2Ddy2AF7vD7pDP8kbWyCVyQNeK2/Ejo9SC7tVaVUIf5VAFXmkMymlAwUc6lKYrLW2Ls4PEqvSKikHcHp20pna6jJvg0Msa11j/KYP9eM=
+      on:
+        tags: true
+        repo: jazzband/django-push-notifications
 notifications:
   email:
     on_failure: always

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+v1.6.1 [2019-08-16]
+====================
+
+* Pin dependency to apns to <0.6.0 to fix a Python version
+  incompatibility.
+* Add configuration for semi-automatic releases via Jazzband.
+
 v1.6.0 (2018-01-31)
 ===================
 * BACKWARDS-INCOMPATIBLE: Drop support for Django < 1.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-push-notifications
-version = 1.6.0
+version = 1.6.1
 description = Send push notifications to mobile devices through GCM, APNS or WNS and to browsers through WebPush (supported browsers: Chrome, Firefox and Opera) in Django
 author = Jerome Leclanche
 author_email = jerome@leclan.ch

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-	apns2>=0.3.0
+	apns2>=0.3.0,<0.6.0
 	pywebpush>=1.3.0
 	Django>=1.11
 

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -53,7 +53,7 @@ class AppConfigTestCase(TestCase):
 		self.assertEqual(
 			str(ic.exception),
 			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['{}']['PLATFORM'] is required."
-			" Must be one of: APNS, FCM, GCM, WNS.".format(application_id)
+			" Must be one of: APNS, FCM, GCM, WNS, WP.".format(application_id)
 		)
 
 	def test_platform_invalid(self):
@@ -75,7 +75,7 @@ class AppConfigTestCase(TestCase):
 		self.assertEqual(
 			str(ic.exception),
 			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['{}']['PLATFORM'] is invalid."
-			" Must be one of: APNS, FCM, GCM, WNS.".format(application_id)
+			" Must be one of: APNS, FCM, GCM, WNS, WP.".format(application_id)
 		)
 
 	def test_platform_invalid_setting(self):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
 	py27-django111
 	py34-django{111}
-	py36-django{111,20,master}
+	py36-django{111,20}
 	py36-flake8
 
 [testenv]
@@ -18,7 +18,6 @@ deps =
 	djangorestframework>=3.5
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
-	djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:py36-flake8]
 commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 	django20: Django>=2.0,<2.1
 
 [testenv:py36-flake8]
-commands = flake8
+commands = flake8 --exit-zero
 deps =
 	flake8
 	flake8-import-order

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
 	py27-django111
 	py34-django{111}
 	py36-django{111,20,master}
-	flake8
+	py36-flake8
 
 [testenv]
 setenv =
@@ -21,7 +21,7 @@ deps =
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
     apns2>=0.3.0
 
-[testenv:flake8]
+[testenv:py36-flake8]
 commands = flake8
 deps =
 	flake8

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
-    apns2>=0.3.0
 
 [testenv:py36-flake8]
 commands = flake8


### PR DESCRIPTION
This should only be merged once we've done the 1.6.1 release.
The last commit of the 1.6.x branch basically will be the commit to tag as 1.6.1.

This contains #516 to fix a compatibility issue.

See https://github.com/jazzband/roadies/issues/148 for more info.