### PR TITLE
apns-collapse-id

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -78,6 +78,8 @@ def _apns_send(
 		except ValueError:
 			raise APNSUnsupportedPriority("Unsupported priority %d" % (priority))
 
+	notification_kwargs["collapse_id"] = kwargs.pop("collapse_id", None)
+
 	if batch:
 		data = [apns2_client.Notification(
 			token=rid, payload=_apns_prepare(rid, alert, **kwargs)) for rid in registration_id]

--- a/tests/test_apns_push_payload.py
+++ b/tests/test_apns_push_payload.py
@@ -83,6 +83,18 @@ class APNSPushPayloadTest(TestCase):
 					self.assertEqual(kargs["priority"], NotificationPriority.Immediate)
 					self.assertEqual(kargs["expiration"], 30)
 
+	def test_collapse_id(self):
+		with mock.patch("apns2.credentials.init_context"):
+			with mock.patch("apns2.client.APNsClient.connect"):
+				with mock.patch("apns2.client.APNsClient.send_notification") as s:
+					_apns_send(
+						"123", "sample", collapse_id="456789"
+					)
+					args, kargs = s.call_args
+					self.assertEqual(args[0], "123")
+					self.assertEqual(args[1].alert, "sample")
+					self.assertEqual(kargs["collapse_id"], "456789")
+
 	def test_bad_priority(self):
 		with mock.patch("apns2.credentials.init_context"):
 			with mock.patch("apns2.client.APNsClient.connect"):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
 	pytest
 	pytest-django
 	mock
+	pywebpush
 	djangorestframework>=3.5
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1


### PR DESCRIPTION
This Pull Requests adds to the existing apns-collapse-id PR by adding the requested basic test to ensure the collapse_id is being set and passed to apns2.