### PR TITLE
Support newest version of pyapns2 with backwards compatibility

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -55,8 +55,9 @@ def _apns_prepare(
 			badge = badge(token)
 
 		return apns2_payload.Payload(
-			apns2_alert, badge, sound, content_available, mutable_content, category,
-			url_args, custom=extra, thread_id=thread_id)
+			alert=apns2_alert, badge=badge, sound=sound, category=category,
+			url_args=url_args, custom=extra, thread_id=thread_id,
+			content_available=content_available, mutable_content=mutable_content)
 
 
 def _apns_send(

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-	apns2>=0.3.0,<0.6.0
+	apns2>=0.3.0,<0.6.0;python_version<"3.5"
+	apns2>=0.3.0;python_version>="3.5"
 	pywebpush>=1.3.0
 	Django>=1.11
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-	py27-django111
-	py{36,37}-django{111,20,22}
+	py27-django111-apns{030,060}
+	py{36,37}-django{111,20,22}-apns{030,060}
 	py37-flake8
 
 [testenv]
@@ -19,6 +19,8 @@ deps =
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
 	django22: Django>=2.2
+	apns030: apns2>=0.3.0,<0.6.0
+	apns060: apns2>=0.6.0
 
 [testenv:py37-flake8]
 commands = flake8 --exit-zero


### PR DESCRIPTION
* Reorders the Payload arguments to support latest pyapns2 0.6.0.
* Selects correct version of pyapns2 based on current python version.
* Update tox.ini to test both versions of pyapns2.

Resolves: #515, #518, #520