### PR TITLE
Squash some warnings

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -95,7 +95,7 @@ class GCMModelTestCase(TestCase):
 				GCMDevice.objects.all().send_message(
 					None, extra={"title": "bar", "body": "foo"}, collapse_key="test_key"
 				)
-				self.assertEquals(p.call_count, 2)
+				self.assertEqual(p.call_count, 2)
 				p.assert_has_calls([
 					mock.call(
 						json.dumps({

--- a/tests/test_wns.py
+++ b/tests/test_wns.py
@@ -88,12 +88,12 @@ class WNSDictToXmlSchemaTestCase(TestCase):
 		xml_tree = dict_to_xml_schema(xml_data)
 		self.assertEqual(xml_tree.tag, "toast")
 		self.assertEqual(xml_tree.attrib, {"key": "value"})
-		visual = xml_tree.getchildren()[0]
+		visual = list(xml_tree)[0]
 		self.assertEqual(visual.tag, "visual")
-		binding = visual.getchildren()[0]
+		binding = list(visual)[0]
 		self.assertEqual(binding.tag, "binding")
 		self.assertEqual(binding.attrib, {"template": "ToastText01"})
-		text = binding.getchildren()[0]
+		text = list(binding)[0]
 		self.assertEqual(text.tag, "text")
 		self.assertEqual(text.attrib, {"id": "1"})
 		self.assertEqual(text.text, "toast notification")
@@ -125,13 +125,12 @@ class WNSDictToXmlSchemaTestCase(TestCase):
 		xml_tree = dict_to_xml_schema(xml_data)
 		self.assertEqual(xml_tree.tag, "toast")
 		self.assertEqual(xml_tree.attrib, {"key": "value"})
-		visual = xml_tree.getchildren()[0]
+		visual = list(xml_tree)[0]
 		self.assertEqual(visual.tag, "visual")
-		binding = visual.getchildren()[0]
+		binding = list(visual)[0]
 		self.assertEqual(binding.tag, "binding")
 		self.assertEqual(binding.attrib, {"template": "ToastText02"})
-		children = binding.getchildren()
-		self.assertEqual(len(children), 2)
+		self.assertEqual(len(list(binding)), 2)
 
 	def test_create_two_multi_sub_element_xml_from_dict(self):
 		xml_data = {
@@ -166,10 +165,9 @@ class WNSDictToXmlSchemaTestCase(TestCase):
 		xml_tree = dict_to_xml_schema(xml_data)
 		self.assertEqual(xml_tree.tag, "toast")
 		self.assertEqual(xml_tree.attrib, {"key": "value"})
-		visual = xml_tree.getchildren()[0]
+		visual = list(xml_tree)[0]
 		self.assertEqual(visual.tag, "visual")
-		binding = visual.getchildren()[0]
+		binding = list(visual)[0]
 		self.assertEqual(binding.tag, "binding")
 		self.assertEqual(binding.attrib, {"template": "ToastText02"})
-		children = binding.getchildren()
-		self.assertEqual(len(children), 4)
+		self.assertEqual(len(list(binding)), 4)


### PR DESCRIPTION
The last remaining warning is:

`Remove the context parameter from HexIntegerField.from_db_value(). Support for it will be removed in Django 3.0`.

We'll need a solution for either replacing HexIntegerField or ditching older Django versions.