### PR TITLE
Make unused arguments part of an asterisk parameter

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -98,7 +98,7 @@ class HexIntegerField(models.BigIntegerField):
 			value = _unsigned_to_signed_integer(value)
 		return value
 
-	def from_db_value(self, value, expression, connection, context):
+	def from_db_value(self, value, *args):
 		""" Return an unsigned int representation from all db backends """
 		if value is None:
 			return value


### PR DESCRIPTION
Django 3.0 will remove `context` from the signature for the `from_db_value` method. This is showing a warning when I run the tests locally. 

```
RemovedInDjango30Warning: Remove the context parameter from HexIntegerField.from_db_value(). Support for it will be removed in Django 3.0.
```

These extra parameters are not used, so we could make them part of an asterisk parameter to avoid the warning, and keep the compatibility. 