### PR TITLE
Added setting to make registration_id fields on all device models unique

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,7 @@ For WNS, you need both the ``WNS_PACKAGE_SECURITY_KEY`` and the ``WNS_SECRET_KEY
 
 - ``USER_MODEL``: Your user model of choice. Eg. ``myapp.User``. Defaults to ``settings.AUTH_USER_MODEL``.
 - ``UPDATE_ON_DUPLICATE_REG_ID``: Transform create of an existing Device (based on registration id) into a update. See below `Update of device with duplicate registration ID`_ for more details.
+- ``UNIQUE_REG_ID``: Forces the ``registration_id`` field on all device models to be unique.
 
 **APNS settings**
 

--- a/push_notifications/migrations/0007_uniquesetting.py
+++ b/push_notifications/migrations/0007_uniquesetting.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_notifications', '0006_webpushdevice'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='apnsdevice',
+            name='registration_id',
+            field=models.CharField(max_length=200, unique=SETTINGS['UNIQUE_REG_ID'], verbose_name='Registration ID'),
+        ),
+        migrations.AlterField(
+            model_name='gcmdevice',
+            name='registration_id',
+            field=models.TextField(unique=SETTINGS['UNIQUE_REG_ID'], verbose_name='Registration ID'),
+        ),
+        migrations.AlterField(
+            model_name='webpushdevice',
+            name='registration_id',
+            field=models.TextField(unique=SETTINGS['UNIQUE_REG_ID'], verbose_name='Registration ID'),
+        ),
+        migrations.AlterField(
+            model_name='wnsdevice',
+            name='registration_id',
+            field=models.TextField(unique=SETTINGS['UNIQUE_REG_ID'], verbose_name='Notification URI'),
+        ),
+    ]

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -90,7 +90,7 @@ class GCMDevice(Device):
 		verbose_name=_("Device ID"), blank=True, null=True, db_index=True,
 		help_text=_("ANDROID_ID / TelephonyManager.getDeviceId() (always as hex)")
 	)
-	registration_id = models.TextField(verbose_name=_("Registration ID"))
+	registration_id = models.TextField(verbose_name=_("Registration ID"), unique=SETTINGS["UNIQUE_REG_ID"])
 	cloud_message_type = models.CharField(
 		verbose_name=_("Cloud Message Type"), max_length=3,
 		choices=CLOUD_MESSAGE_TYPES, default="GCM",
@@ -148,7 +148,7 @@ class APNSDevice(Device):
 		help_text="UDID / UIDevice.identifierForVendor()"
 	)
 	registration_id = models.CharField(
-		verbose_name=_("Registration ID"), max_length=200, unique=True
+		verbose_name=_("Registration ID"), max_length=200, unique=SETTINGS["UNIQUE_REG_ID"]
 	)
 
 	objects = APNSDeviceManager()
@@ -198,7 +198,7 @@ class WNSDevice(Device):
 		verbose_name=_("Device ID"), blank=True, null=True, db_index=True,
 		help_text=_("GUID()")
 	)
-	registration_id = models.TextField(verbose_name=_("Notification URI"))
+	registration_id = models.TextField(verbose_name=_("Notification URI"), unique=SETTINGS["UNIQUE_REG_ID"])
 
 	objects = WNSDeviceManager()
 
@@ -230,7 +230,7 @@ class WebPushDeviceQuerySet(models.query.QuerySet):
 
 
 class WebPushDevice(Device):
-	registration_id = models.TextField(verbose_name=_("Registration ID"))
+	registration_id = models.TextField(verbose_name=_("Registration ID"), unique=SETTINGS["UNIQUE_REG_ID"])
 	p256dh = models.CharField(
 		verbose_name=_("User public encryption key"),
 		max_length=88)

--- a/push_notifications/settings.py
+++ b/push_notifications/settings.py
@@ -49,5 +49,8 @@ PUSH_NOTIFICATIONS_SETTINGS.setdefault("WP_ERROR_TIMEOUT", None)
 # User model
 PUSH_NOTIFICATIONS_SETTINGS.setdefault("USER_MODEL", settings.AUTH_USER_MODEL)
 
+# Unique registration ID for all devices
+PUSH_NOTIFICATIONS_SETTINGS.setdefault("UNIQUE_REG_ID", False)
+
 # API endpoint settings
 PUSH_NOTIFICATIONS_SETTINGS.setdefault("UPDATE_ON_DUPLICATE_REG_ID", False)

--- a/tests/settings_unique.py
+++ b/tests/settings_unique.py
@@ -1,0 +1,31 @@
+# assert warnings are enabled
+import warnings
+
+
+warnings.simplefilter("ignore", Warning)
+
+
+DATABASES = {
+	"default": {
+		"ENGINE": "django.db.backends.sqlite3",
+	}
+}
+
+INSTALLED_APPS = [
+	"django.contrib.admin",
+	"django.contrib.auth",
+	"django.contrib.contenttypes",
+	"django.contrib.sessions",
+	"django.contrib.sites",
+	"push_notifications",
+]
+
+SITE_ID = 1
+ROOT_URLCONF = "core.urls"
+
+SECRET_KEY = "foobar"
+
+PUSH_NOTIFICATIONS_SETTINGS = {
+	"WP_CLAIMS": {"sub": "mailto: jazzband@example.com"},
+	"UNIQUE_REG_ID": True
+}

--- a/tests/tst_unique.py
+++ b/tests/tst_unique.py
@@ -1,0 +1,53 @@
+
+from __future__ import absolute_import
+
+import pytest
+from django.db import IntegrityError
+from django.test import TestCase
+from push_notifications.models import APNSDevice, GCMDevice, WNSDevice, WebPushDevice
+
+
+class GCMModelTestCase(TestCase):
+	def test_throws_error_for_same_gcm_registration_id(self):
+		device = GCMDevice.objects.create(
+			registration_id="unique_id", cloud_message_type="GCM"
+		)
+		assert device.id is not None
+		with pytest.raises(IntegrityError) as excinfo:
+			GCMDevice.objects.create(
+				registration_id="unique_id", cloud_message_type="GCM"
+			)
+		assert "UNIQUE constraint failed" in str(excinfo.value)
+
+	def test_throws_error_for_same_apns_registration_id(self):
+		device = APNSDevice.objects.create(
+			registration_id="unique_id",
+		)
+		assert device.id is not None
+		with pytest.raises(IntegrityError) as excinfo:
+			APNSDevice.objects.create(
+				registration_id="unique_id",
+			)
+		assert "UNIQUE constraint failed" in str(excinfo.value)
+
+	def test_throws_error_for_same_wns_registration_id(self):
+		device = WNSDevice.objects.create(
+			registration_id="unique_id",
+		)
+		assert device.id is not None
+		with pytest.raises(IntegrityError) as excinfo:
+			WNSDevice.objects.create(
+				registration_id="unique_id",
+			)
+		assert "UNIQUE constraint failed" in str(excinfo.value)
+
+	def test_throws_error_for_same_web_registration_id(self):
+		device = WebPushDevice.objects.create(
+			registration_id="unique_id",
+		)
+		assert device.id is not None
+		with pytest.raises(IntegrityError) as excinfo:
+			WebPushDevice.objects.create(
+				registration_id="unique_id",
+			)
+		assert "UNIQUE constraint failed" in str(excinfo.value)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ setenv =
 	PYTHONWARNINGS = all
 	DJANGO_SETTINGS_MODULE = tests.settings
 	PYTHONPATH = {toxinidir}
-commands = pytest
+commands =
+	pytest
+	pytest --ds=tests.settings_unique tests/tst_unique.py
 deps =
 	pytest
 	pytest-django


### PR DESCRIPTION
I saw the PR https://github.com/jazzband/django-push-notifications/pull/487 and the https://github.com/jazzband/django-push-notifications/pull/487#issuecomment-499132978 by @odinuge and decided to implement just the registration_id unique changes.

Thanks to @goinnn for the work :)

The PR will close the following Issues: #442, #184, #41

I tried to implement testing as smooth as possible but for testing the unique registration_id i have to recreate the database. If anyone has a better idea it's more than welcome :blush:.