### PR TITLE
Test python 3.8 and Django 3.0 and align doc version specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 
 # tox
 .tox
+*.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 sudo: false
 language: python
 python:
+- 3.5
 - 3.6
 - 3.7
 - 3.8

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ UPDATE_ON_DUPLICATE_REG_ID: Transform create of an existing Device (based on reg
 
 Dependencies
 ------------
-- Python 2.7 or 3.4+
+- Python 3.5+
 - Django 1.11+
 - For the API module, Django REST Framework 3.7+ is required.
 - For WebPush (WP), pywebpush 1.3.0+ is required. py-vapid 1.3.0+ is required for generating the WebPush private key; however this

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,15 +12,17 @@ classifiers =
 	Framework :: Django
 	Framework :: Django :: 1.11
 	Framework :: Django :: 2.0
+	Framework :: Django :: 2.1
+	Framework :: Django :: 2.2
+	Framework :: Django :: 3.0
 	Intended Audience :: Developers
 	License :: OSI Approved :: MIT License
 	Programming Language :: Python
-	Programming Language :: Python :: 2.7
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.4
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
 	Topic :: Internet :: WWW/HTTP
 	Topic :: System :: Networking
 

--- a/tests/tst_unique.py
+++ b/tests/tst_unique.py
@@ -1,6 +1,3 @@
-
-from __future__ import absolute_import
-
 import pytest
 from django.db import IntegrityError
 from django.test import TestCase

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-	py27-django111-apns{030,060}
-	py{36,37}-django{111,20,22}-apns{030,060}
+	py{35,36,37,38}-django{111,20,21,22}-apns{030,060}
+	py{36,37,38}-django30-apns{030,060}
 	py37-flake8
 
 [testenv]
@@ -17,10 +17,12 @@ deps =
 	pytest-django
 	mock
 	pywebpush
-	djangorestframework>=3.5
+	djangorestframework>=3.7
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
-	django22: Django>=2.2
+	django21: Django>=2.1,<2.2
+	django22: Django>=2.2,<3.0
+	django30: Django>=3.0,<3.1
 	apns030: apns2>=0.3.0,<0.6.0
 	apns060: apns2>=0.6.0
 


### PR DESCRIPTION
We're trying to upgrade to Django 3.0 as soon as possible, so I'm going through all our dependencies and helping ensure they work on the latest version of everything.