### PR TITLE
registration_id no longer hard-coded in DeviceViewSetMixin

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -138,9 +138,9 @@ class DeviceViewSetMixin(object):
 	def create(self, request, *args, **kwargs):
 		serializer = None
 		is_update = False
-		if SETTINGS.get("UPDATE_ON_DUPLICATE_REG_ID") and "registration_id" in request.data:
+		if SETTINGS.get("UPDATE_ON_DUPLICATE_REG_ID") and self.lookup_field in request.data:
 			instance = self.queryset.model.objects.filter(
-				registration_id=request.data["registration_id"]
+				registration_id=request.data[self.lookup_field]
 			).first()
 			if instance:
 				serializer = self.get_serializer(instance, data=request.data)


### PR DESCRIPTION
`lookup_field` was declared in `DeviceViewSetMixin` and never used. Instead the create method referred to string literal instead of this field. 

Now the field is used and `registration_id` is no loger hardcoded in create method. 

You can now inherit from `DeviceViewSetMixin`, redefined the `lookup_field` and use if with your views instead of having to rewrite the `create` method yourself