### PR TITLE
Edit old migrations to use new USER_MODEL setting value

### DIFF
--- a/push_notifications/migrations/0001_initial.py
+++ b/push_notifications/migrations/0001_initial.py
@@ -4,6 +4,8 @@ from django.db import migrations, models
 
 import push_notifications.fields
 
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+
 
 class Migration(migrations.Migration):
 
@@ -21,7 +23,7 @@ class Migration(migrations.Migration):
                 ('date_created', models.DateTimeField(auto_now_add=True, verbose_name='Creation date', null=True)),
                 ('device_id', models.UUIDField(help_text='UDID / UIDevice.identifierForVendor()', max_length=32, null=True, verbose_name='Device ID', blank=True, db_index=True)),
                 ('registration_id', models.CharField(unique=True, max_length=64, verbose_name='Registration ID')),
-                ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(blank=True, to=SETTINGS["USER_MODEL"], null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'APNS device',
@@ -37,7 +39,7 @@ class Migration(migrations.Migration):
                 ('date_created', models.DateTimeField(auto_now_add=True, verbose_name='Creation date', null=True)),
                 ('device_id', push_notifications.fields.HexIntegerField(help_text='ANDROID_ID / TelephonyManager.getDeviceId() (always as hex)', null=True, verbose_name='Device ID', blank=True, db_index=True)),
                 ('registration_id', models.TextField(verbose_name='Registration ID')),
-                ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(blank=True, to=SETTINGS["USER_MODEL"], null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'GCM device',

--- a/push_notifications/migrations/0003_wnsdevice.py
+++ b/push_notifications/migrations/0003_wnsdevice.py
@@ -4,6 +4,7 @@ import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
 
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 
 class Migration(migrations.Migration):
 
@@ -22,7 +23,7 @@ class Migration(migrations.Migration):
                 ('date_created', models.DateTimeField(auto_now_add=True, null=True, verbose_name='Creation date')),
                 ('device_id', models.UUIDField(blank=True, db_index=True, help_text='GUID()', null=True, verbose_name='Device ID')),
                 ('registration_id', models.TextField(verbose_name='Notification URI')),
-                ('user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=SETTINGS["USER_MODEL"])),
             ],
             options={
                 'verbose_name': 'WNS device',

--- a/push_notifications/migrations/0006_webpushdevice.py
+++ b/push_notifications/migrations/0006_webpushdevice.py
@@ -2,6 +2,7 @@
 from django.conf import settings
 from django.db import migrations, models
 
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 
 class Migration(migrations.Migration):
 
@@ -23,7 +24,7 @@ class Migration(migrations.Migration):
                 ('p256dh', models.CharField(max_length=88, verbose_name='User public encryption key')),
                 ('auth', models.CharField(max_length=24, verbose_name='User auth secret')),
                 ('browser', models.CharField(default='CHROME', help_text='Currently only support to Chrome, Firefox and Opera browsers', max_length=10, verbose_name='Browser', choices=[('CHROME', 'Chrome'), ('FIREFOX', 'Firefox'), ('OPERA', 'Opera')])),
-                ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(blank=True, to=SETTINGS["USER_MODEL"], null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'WebPush device',


### PR DESCRIPTION
The `USER_MODEL` setting appears very useful, but in the 2.0.0 release, the original tables are created with `user` as a ForeignKey to `settings.AUTH_USER_MODEL`.

This creates several problems, including that `./manage.py makemigrations` will create a migration in `push_notifications` that can't be committed or deployed if the project was installed from pypi.

This PR edits old migrations to use `USER_MODEL` directly. For new users, this seems to honor the intention of the feature. For existing users, they should expect trouble if they ever change the `USER_MODEL` or `AUTH_USER_MODEL` settings, with or without this patch.