### PR TITLE
Django 4.0 warnings

### DIFF
--- a/push_notifications/admin.py
+++ b/push_notifications/admin.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.contrib import admin, messages
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .apns import APNSServerError
 from .gcm import GCMError

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .fields import HexIntegerField
 from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS


### PR DESCRIPTION
swapping from ugettext_lazy to gettext_lazy. If I find any other Django 4.0 warnings I will update/make a new PR.