### PR TITLE
Drop python 2.x and django before 2.2

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -132,7 +132,7 @@ class IsOwner(permissions.BasePermission):
 
 
 # Mixins
-class DeviceViewSetMixin(object):
+class DeviceViewSetMixin:
 	lookup_field = "registration_id"
 
 	def create(self, request, *args, **kwargs):
@@ -168,7 +168,7 @@ class DeviceViewSetMixin(object):
 		return super(DeviceViewSetMixin, self).perform_update(serializer)
 
 
-class AuthorizedMixin(object):
+class AuthorizedMixin:
 	permission_classes = (permissions.IsAuthenticated, IsOwner)
 
 	def get_queryset(self):

--- a/push_notifications/compat.py
+++ b/push_notifications/compat.py
@@ -1,10 +1,4 @@
 # flake8:noqa
-
-try:
-	from urllib.error import HTTPError
-	from urllib.parse import urlencode
-	from urllib.request import Request, urlopen
-except ImportError:
-	# Python 2 support
-	from urllib2 import HTTPError, Request, urlopen
-	from urllib import urlencode
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen

--- a/push_notifications/conf/base.py
+++ b/push_notifications/conf/base.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ImproperlyConfigured
 
 
-class BaseConfig(object):
+class BaseConfig:
 	def has_auth_token_creds(self, application_id=None):
 		raise NotImplementedError
 

--- a/push_notifications/conf/legacy.py
+++ b/push_notifications/conf/legacy.py
@@ -9,7 +9,7 @@ __all__ = [
 ]
 
 
-class empty(object):
+class empty:
 	pass
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,19 +10,17 @@ classifiers =
 	Development Status :: 5 - Production/Stable
 	Environment :: Web Environment
 	Framework :: Django
-	Framework :: Django :: 1.11
-	Framework :: Django :: 2.0
-	Framework :: Django :: 2.1
 	Framework :: Django :: 2.2
 	Framework :: Django :: 3.0
+	Framework :: Django :: 3.1
 	Intended Audience :: Developers
 	License :: OSI Approved :: MIT License
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
 	Topic :: Internet :: WWW/HTTP
 	Topic :: System :: Networking
 
@@ -32,7 +30,7 @@ install_requires =
 	apns2>=0.3.0,<0.6.0;python_version<"3.5"
 	apns2>=0.3.0;python_version>="3.5"
 	pywebpush>=1.3.0
-	Django>=1.11
+	Django>=2.2
 
 [options.packages.find]
 exclude = tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-	py{35,36,37,38,39}-django{111,20,21,22}-apns{030,060}
-	py{36,37,38,39}-django30-apns{030,060}
+	py{36,37,38,39}-django{22}-apns{030,060}
+	py{36,37,38,39}-django{30,31}-apns{030,060}
 	py37-flake8
 
 [testenv]
@@ -18,11 +18,9 @@ deps =
 	mock
 	pywebpush
 	djangorestframework==3.11.0
-	django111: Django>=1.11,<2.0
-	django20: Django>=2.0,<2.1
-	django21: Django>=2.1,<2.2
 	django22: Django>=2.2,<3.0
 	django30: Django>=3.0,<3.1
+	django31: Django>=3.1,<3.2
 	apns030: apns2>=0.3.0,<0.6.0
 	apns060: apns2>=0.6.0
 


### PR DESCRIPTION
Since Python 2.x is EOL and also Django before 2.2 tests and code are updated to work with python3.