### PR TITLE
Make push optional dependecies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,9 @@ Dependencies
 - Python 3.6+
 - Django 2.2+
 - For the API module, Django REST Framework 3.7+ is required.
-- For WebPush (WP), pywebpush 1.3.0+ is required. py-vapid 1.3.0+ is required for generating the WebPush private key; however this
+- For WebPush (WP), pywebpush 1.3.0+ is required (optional). py-vapid 1.3.0+ is required for generating the WebPush private key; however this
   step does not need to occur on the application server.
+- For Apple Push (APNS), apns2 0.3+ is required (optional).
 
 Setup
 -----
@@ -43,7 +44,7 @@ You can install the library directly from pypi using pip:
 
 .. code-block:: shell
 
-	$ pip install django-push-notifications
+	$ pip install django-push-notifications[WP,APNS]
 
 
 Edit your settings.py file:

--- a/push_notifications/admin.py
+++ b/push_notifications/admin.py
@@ -3,11 +3,9 @@ from django.contrib import admin, messages
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
-from .apns import APNSServerError
-from .gcm import GCMError
+from .exceptions import APNSServerError, GCMError, WebPushError
 from .models import APNSDevice, GCMDevice, WebPushDevice, WNSDevice
 from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
-from .webpush import WebPushError
 
 
 User = apps.get_model(*SETTINGS["USER_MODEL"].split("."))

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -13,21 +13,7 @@ from apns2 import payload as apns2_payload
 
 from . import models
 from .conf import get_manager
-from .exceptions import NotificationError
-
-
-class APNSError(NotificationError):
-	pass
-
-
-class APNSUnsupportedPriority(APNSError):
-	pass
-
-
-class APNSServerError(APNSError):
-	def __init__(self, status):
-		super(APNSServerError, self).__init__(status)
-		self.status = status
+from .exceptions import APNSError, APNSUnsupportedPriority, APNSServerError
 
 
 def _apns_create_socket(creds=None, application_id=None):

--- a/push_notifications/exceptions.py
+++ b/push_notifications/exceptions.py
@@ -1,2 +1,27 @@
 class NotificationError(Exception):
 	pass
+
+
+# APNS
+class APNSError(NotificationError):
+	pass
+
+
+class APNSUnsupportedPriority(APNSError):
+	pass
+
+
+class APNSServerError(APNSError):
+	def __init__(self, status):
+		super().__init__(status)
+		self.status = status
+
+
+# GCM
+class GCMError(NotificationError):
+	pass
+
+
+# Web Push
+class WebPushError(NotificationError):
+	pass

--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from .compat import Request, urlopen
 from .conf import get_manager
-from .exceptions import NotificationError
+from .exceptions import GCMError
 from .models import GCMDevice
 
 
@@ -28,11 +28,6 @@ FCM_NOTIFICATIONS_PAYLOAD_KEYS = [
 	"title", "body", "icon", "sound", "badge", "color", "tag", "click_action",
 	"body_loc_key", "body_loc_args", "title_loc_key", "title_loc_args", "android_channel_id"
 ]
-
-
-class GCMError(NotificationError):
-	pass
-
 
 def _chunks(l, n):
 	"""

--- a/push_notifications/webpush.py
+++ b/push_notifications/webpush.py
@@ -1,11 +1,7 @@
 from pywebpush import WebPushException, webpush
 
 from .conf import get_manager
-from .exceptions import NotificationError
-
-
-class WebPushError(NotificationError):
-	pass
+from .exceptions import WebPushError
 
 
 def get_subscription_info(application_id, uri, browser, auth, p256dh):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,13 +27,21 @@ classifiers =
 python_requires = >= 3.6
 packages = find:
 install_requires =
+	Django>=2.2
+
+setup_requires =
+	setuptools_scm
+
+[options.extras_require]
+APNS =
 	apns2>=0.3.0,<0.6.0;python_version<"3.5"
 	apns2>=0.3.0;python_version>="3.5"
 	importlib-metadata;python_version < "3.8"
 	pywebpush>=1.3.0
 	Django>=2.2
-setup_requires =
-	setuptools_scm
+
+WP = pywebpush>=1.3.0
+
 
 [options.packages.find]
 exclude = tests

--- a/tests/_mock.py
+++ b/tests/_mock.py
@@ -1,4 +1,0 @@
-try:
-	from unittest import mock  # noqa
-except ImportError:
-	from mock import mock  # noqa

--- a/tests/test_apns_models.py
+++ b/tests/test_apns_models.py
@@ -1,12 +1,12 @@
+from unittest import mock
+
 from apns2.client import NotificationPriority
 from apns2.errors import BadTopic, PayloadTooLarge, Unregistered
 from django.conf import settings
 from django.test import TestCase, override_settings
 
-from push_notifications.apns import APNSError
+from push_notifications.exceptions import APNSError
 from push_notifications.models import APNSDevice
-
-from ._mock import mock
 
 
 class APNSModelTestCase(TestCase):

--- a/tests/test_apns_push_payload.py
+++ b/tests/test_apns_push_payload.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 from apns2.client import NotificationPriority
 from django.test import TestCase
 
-from push_notifications.apns import APNSUnsupportedPriority, _apns_send
-
-from ._mock import mock
+from push_notifications.apns import _apns_send
+from push_notifications.exceptions import APNSUnsupportedPriority
 
 
 class APNSPushPayloadTest(TestCase):

--- a/tests/test_gcm_push_payload.py
+++ b/tests/test_gcm_push_payload.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from django.test import TestCase
 
 from push_notifications.gcm import send_bulk_message, send_message
 
-from ._mock import mock
 from .responses import GCM_JSON, GCM_JSON_MULTIPLE
 
 

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -2,7 +2,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
 from push_notifications.conf import LegacyConfig, get_manager
-from push_notifications.webpush import WebPushError, webpush_send_message
+from push_notifications.exceptions import WebPushError
+from push_notifications.webpush import webpush_send_message
 
 
 class LegacyConfigTestCase(TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 from django.test import TestCase
 from django.utils import timezone
@@ -8,7 +9,6 @@ from push_notifications.gcm import GCMError, send_bulk_message
 from push_notifications.models import APNSDevice, GCMDevice
 
 from . import responses
-from ._mock import mock
 
 
 class GCMModelTestCase(TestCase):

--- a/tests/test_wns.py
+++ b/tests/test_wns.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import xml.etree.ElementTree as ET
 
 from django.test import TestCase
@@ -5,8 +6,6 @@ from django.test import TestCase
 from push_notifications.wns import (
 	dict_to_xml_schema, wns_send_bulk_message, wns_send_message
 )
-
-from ._mock import mock
 
 
 class WNSSendMessageTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    mock
     pywebpush
     djangorestframework==3.11.0
     dj22: Django>=2.2,<3.0


### PR DESCRIPTION
In some use-cases this package is used only to serve a subset of available push services.

In this case having every push-library as a required dependecy may cause problems with the environment (ie: dependecies of dependency).

This PR turns APNS and webpush as optional dependencies using [`extras_require`](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies) option.