### PR TITLE
Change feature detection logic for database field

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -14,16 +14,14 @@ UNSIGNED_64BIT_INT_MAX_VALUE = 2 ** 64 - 1
 
 
 hex_re = re.compile(r"^(([0-9A-f])|(0x[0-9A-f]))+$")
-signed_integer_engines = [
-	"django.db.backends.postgresql",
-	"django.db.backends.postgresql_psycopg2",
-	"django.contrib.gis.db.backends.postgis",
-	"django.db.backends.sqlite3"
+signed_integer_vendors = [
+	"postgresql",
+	"sqlite",
 ]
 
 
 def _using_signed_storage():
-	return connection.settings_dict["ENGINE"] in signed_integer_engines
+	return connection.vendor in signed_integer_vendors
 
 
 def _signed_to_unsigned_integer(value):
@@ -79,10 +77,9 @@ class HexIntegerField(models.BigIntegerField):
 	]
 
 	def db_type(self, connection):
-		engine = connection.settings_dict["ENGINE"]
-		if "mysql" in engine:
+		if "mysql" == connection.vendor:
 			return "bigint unsigned"
-		elif "sqlite" in engine:
+		elif "sqlite" == connection.vendor:
 			return "UNSIGNED BIG INT"
 		else:
 			return super(HexIntegerField, self).db_type(connection=connection)


### PR DESCRIPTION
As of now `HexIntegerField` relies on `connection.settings_dict["ENGINE"]` to determinate if the database supports specific feature.

Since a custom engine may be defined by any user this has some limitation because engines are hard-coded.

The preferred approach would be to use `connection.feature_class.<feature>`, but ATM there is no flag in these classes which may help here (ie: `supports_unsigned_integers`).

My solution here is to rely on `connection.vendor` because it should be more robust and could handle subclassing of any existent backend, if that backend has some kind of differences it could just override `vendor` attribute (ie: `postgresql` -> `custom-postgresql`).

Also this saves us some configurations since `django.db.backends.postgresql`, `django.db.backends.postgresql_psycopg2` and `django.contrib.gis.db.backends.postgis` have all `vendor = "posrgresql"`, and we also get spatiallite (which is based on sqlite and has the same datatypes).

