### PR TITLE
++Enable sending image in GCM notifications

### DIFF
--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -25,7 +25,7 @@ FCM_OPTIONS_KEYS = [
 	"restricted_package_name", "dry_run", "mutable_content"
 ]
 FCM_NOTIFICATIONS_PAYLOAD_KEYS = [
-	"title", "body", "icon", "sound", "badge", "color", "tag", "click_action",
+	"title", "body", "icon", "image", "sound", "badge", "color", "tag", "click_action",
 	"body_loc_key", "body_loc_args", "title_loc_key", "title_loc_args", "android_channel_id"
 ]
 


### PR DESCRIPTION
Existing behavior sends it under the `data` field which doesn't behave correctly with the native image notifications.

Fixes https://github.com/jazzband/django-push-notifications/issues/559