### PR TITLE
chore: test only active Django versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
-        django-version: ['2.2', '3.0', '3.1']
+        django-version: ['2.2', '3.2']
         include:
+          - django-version: '4.0'
+            python-version: '3.8'
+          - django-version: '4.0'
+            python-version: '3.9'
           - django-version: 'main'
             python-version: '3.8'
           - django-version: 'main'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = true
 envlist =
-    py{36,37,38,39}-dj{22,30,31,32,40}
+    py{36,37,38,39}-dj{22,32,40}
     py{38,39}-djmain
     flake8
 
@@ -16,8 +16,6 @@ python =
 [gh-actions:env]
 DJANGO =
     2.2: dj22
-    3.0: dj30
-    3.1: dj31
     3.2: dj32
     4.0: dj40
     main: djmain
@@ -40,8 +38,6 @@ deps =
     pytz
     djangorestframework==3.11.0
     dj22: Django>=2.2,<3.0
-    dj30: Django>=3.0,<3.1
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Django 3.0 and 3.1 already got on EOF

I also had forgot to add the Django 4.0 on GHA