### PR TITLE
chore: dry tests, use newer DRF on tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
-        django-version: ['2.2', '3.2']
-        include:
-          - django-version: '4.0'
-            python-version: '3.8'
-          - django-version: '4.0'
-            python-version: '3.9'
-          - django-version: 'main'
-            python-version: '3.8'
-          - django-version: 'main'
-            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v2
@@ -51,8 +41,6 @@ jobs:
     - name: Tox tests
       run: |
         tox -v
-      env:
-        DJANGO: ${{ matrix.django-version }}
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,5 +28,3 @@ SECRET_KEY = "foobar"
 PUSH_NOTIFICATIONS_SETTINGS = {
 	"WP_CLAIMS": {"sub": "mailto: jazzband@example.com"}
 }
-
-USE_DEPRECATED_PYTZ = True

--- a/tests/settings_unique.py
+++ b/tests/settings_unique.py
@@ -29,5 +29,3 @@ PUSH_NOTIFICATIONS_SETTINGS = {
 	"WP_CLAIMS": {"sub": "mailto: jazzband@example.com"},
 	"UNIQUE_REG_ID": True
 }
-
-USE_DEPRECATED_PYTZ = True

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist = True
 usedevelop = true
 envlist =
-    py{36,37,38,39}-dj{22,32,40}
-    py{38,39}-djmain
+    py{36,37,38,39}-dj{22,32}
+    py{38,39}-dj{40,main}
     flake8
 
 [gh-actions]
@@ -35,8 +35,7 @@ deps =
     pytest-cov
     pytest-django
     pywebpush
-    pytz
-    djangorestframework==3.11.0
+    djangorestframework
     dj22: Django>=2.2,<3.0
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
@@ -45,7 +44,7 @@ deps =
 [testenv:flake8]
 commands = flake8 --exit-zero
 deps =
-    flake8==3.5.0
+    flake8
     flake8-isort
     flake8-quotes
 


### PR DESCRIPTION
Looking at the [docs](https://github.com/ymyzk/tox-gh-actions#advanced-examples) of tox-gh-action

we could not have the test logic on both places, reducing the duplication and complexity of testing


the new DRF 3.13.0 is full compatible with django 4.0 and it does not need anymore the pytz package