### PR TITLE
feat: Add python3.10 support (ugly workaround)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/push_notifications/__init__.py
+++ b/push_notifications/__init__.py
@@ -5,4 +5,15 @@ except ImportError:
     # <Python 3.7 and lower
     import importlib_metadata
 
+try:
+    # Ugly hack for APNS sub-deps Python 3.10+
+    from collections.abc import Iterable, Mapping, MutableSet, MutableMapping
+    import collections
+    collections.Iterable = Iterable
+    collections.Mapping = Mapping
+    collections.MutableSet = MutableSet
+    collections.MutableMapping = MutableMapping
+except ImportError:
+    pass
+
 __version__ = importlib_metadata.version("django-push-notifications")

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Topic :: Internet :: WWW/HTTP
 	Topic :: System :: Networking
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 skipsdist = True
 usedevelop = true
 envlist =
-    py{36,37,38,39}-dj{22,32}
-    py{38,39}-dj{40,main}
+    py{36,37,38,39}-dj22
+    py{36,37,38,39,310}-dj32
+    py{38,39,310}-dj{40,main}
     flake8
 
 [gh-actions]
@@ -12,6 +13,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39, flake8
+    3.10: py310
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
the sub dependency of apns2 `hyper` is completely abandoned and it does not support python 3.10
simple because it uses some packages from `collections` where on python 3.10 it moved to `collections.abc`

I think the clean way to properly fix it, would be to move to a more maintained package to do Apple Push Notifications.
which might be [aioapns](https://github.com/Fatal1ty/aioapns)
