### PR TITLE
410  Unregistered contains extra timestamp value

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -139,6 +139,11 @@ def apns_send_bulk_message(
 		registration_ids, alert, batch=True, application_id=application_id,
 		creds=creds, **kwargs
 	)
-	inactive_tokens = [token for token, result in results.items() if result == "Unregistered"]
+
+	inactive_tokens = []
+	for token, result in results.items():
+		if isinstance(result, list) and result[0] == "Unregistered":
+			inactive_tokens.append(token)
+	# inactive_tokens = [token for token, result in results.items() if result == "Unregistered"]
 	models.APNSDevice.objects.filter(registration_id__in=inactive_tokens).update(active=False)
 	return results


### PR DESCRIPTION
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns#:~:text=timestamp,field%20is%20410