### PR TITLE
Add django 4.1, remove master branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = true
 envlist =
     py{36,37,38,39}-dj{22,32}
-    py{38,39}-dj{40,41}
+    py{38,39}-dj{40,405}
     flake8
 
 [gh-actions]
@@ -18,7 +18,7 @@ DJANGO =
     2.2: dj22
     3.2: dj32
     4.0: dj40
-	4.1: dj41
+	4.0.5: dj405
 
 [testenv]
 usedevelop = true
@@ -38,8 +38,8 @@ deps =
     djangorestframework
     dj22: Django>=2.2,<3.0
     dj32: Django>=3.2,<3.3
-    dj40: Django>=4.0,<4.1
-	dj41: Django>=4.1,<4.2
+    dj40: Django>=4.0,<4.0.5
+	dj405: Django>=4.0.5,<4.1
 
 [testenv:flake8]
 commands = flake8 --exit-zero

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = true
 envlist =
     py{36,37,38,39}-dj{22,32}
-    py{38,39}-dj{40,main}
+    py{38,39}-dj{40,41}
     flake8
 
 [gh-actions]
@@ -18,7 +18,7 @@ DJANGO =
     2.2: dj22
     3.2: dj32
     4.0: dj40
-    main: djmain
+	4.1: dj41
 
 [testenv]
 usedevelop = true
@@ -39,7 +39,7 @@ deps =
     dj22: Django>=2.2,<3.0
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
-    djmain: https://github.com/django/django/archive/main.tar.gz
+	dj41: Django>=4.1,<4.2
 
 [testenv:flake8]
 commands = flake8 --exit-zero


### PR DESCRIPTION
The django master branch has an incompatibility with the latest django rest framework.