### PR TITLE
Allow APNS tokens of variable length.

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -46,10 +46,10 @@ class APNSDeviceSerializer(ModelSerializer):
 		model = APNSDevice
 
 	def validate_registration_id(self, value):
-		# iOS device tokens are 256-bit hexadecimal (64 characters). In 2016 Apple is increasing
-		# iOS device tokens to 100 bytes hexadecimal (200 characters).
 
-		if hex_re.match(value) is None or len(value) not in (64, 200):
+		# https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622958-application
+		# As of 02/2023 APNS tokens (registration_id) "are of variable length. Do not hard-code their size."
+		if hex_re.match(value) is None:
 			raise ValidationError("Registration ID (device token) is invalid")
 
 		return value

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -45,6 +45,14 @@ class APNSDeviceSerializerTestCase(TestCase):
 		})
 		self.assertTrue(serializer.is_valid())
 
+		# valid data - 200 bytes mixed case
+		serializer = APNSDeviceSerializer(data={
+			"registration_id": "aE" * 200,
+			"name": "Apple iPhone 6+",
+			"device_id": "ffffffffffffffffffffffffffffffff",
+		})
+		self.assertTrue(serializer.is_valid())
+
 		# invalid data - device_id, registration_id
 		serializer = APNSDeviceSerializer(data={
 			"registration_id": "invalid device token contains no hex",


### PR DESCRIPTION
Hopefully solves https://github.com/jazzband/django-push-notifications/issues/537