### PR TITLE
Fix imports of FCM to keep it as an optional dependency

### DIFF
--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -58,9 +58,7 @@ class GCMDeviceManager(models.Manager):
 class GCMDeviceQuerySet(models.query.QuerySet):
 	def send_message(self, message, **kwargs):
 		if self.exists():
-			from firebase_admin import messaging
-
-			from .gcm import dict_to_fcm_message
+			from .gcm import dict_to_fcm_message, messaging
 			from .gcm import send_message as fcm_send_message
 
 			if not isinstance(message, messaging.Message):
@@ -109,9 +107,7 @@ class GCMDevice(Device):
 		verbose_name = _("FCM device")
 
 	def send_message(self, message, **kwargs):
-		from firebase_admin import messaging
-
-		from .gcm import dict_to_fcm_message
+		from .gcm import dict_to_fcm_message, messaging
 		from .gcm import send_message as fcm_send_message
 
 		# GCM is not supported.


### PR DESCRIPTION
As pointed out in this comment https://github.com/jazzband/django-push-notifications/pull/702#discussion_r1489160018 importing `firebase_admin` or `gcm` at top level in `models.py` turns the `firebase_admin` package as a mandatory requirements while it should not.

To address this I have moved the imports inside the appropriated methods. This allow the codebase to run even without the firebase package (which is optional).