### PR TITLE
Add db_index=True for registration_id on APNSDevice model

### DIFF
--- a/push_notifications/migrations/0011_alter_apnsdevice_registration_id.py
+++ b/push_notifications/migrations/0011_alter_apnsdevice_registration_id.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_notifications', '0010_alter_gcmdevice_options_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='apnsdevice',
+            name='registration_id',
+            field=models.CharField(db_index=not SETTINGS['UNIQUE_REG_ID'], unique=SETTINGS['UNIQUE_REG_ID'], max_length=200, verbose_name='Registration ID'),
+        ),
+    ]

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -164,7 +164,9 @@ class APNSDevice(Device):
 		help_text=_("UUID / UIDevice.identifierForVendor()")
 	)
 	registration_id = models.CharField(
-		verbose_name=_("Registration ID"), max_length=200, unique=SETTINGS["UNIQUE_REG_ID"]
+		verbose_name=_("Registration ID"), max_length=200,
+		db_index=not SETTINGS["UNIQUE_REG_ID"],
+		unique=SETTINGS["UNIQUE_REG_ID"],
 	)
 
 	objects = APNSDeviceManager()


### PR DESCRIPTION
When having huge list apns devices without the unique setting activated (UNIQUE_REG_ID) updating devices via the drf-endpoint becomes very slow. Adding an index resolves that.

For reference our current prod-environment have select-statements to this fields taking up to 9 seconds under heavy load. 