### PR TITLE
Add Support for mutable_content in aioapns

### DIFF
--- a/push_notifications/apns_async.py
+++ b/push_notifications/apns_async.py
@@ -222,6 +222,7 @@ def apns_send_message(
 	loc_key: str = None,
 	priority: int = None,
 	collapse_id: str = None,
+	mutable_content: int = None,
 	err_func: ErrFunc = None,
 ):
 	"""
@@ -253,6 +254,7 @@ def apns_send_message(
 		loc_key=loc_key,
 		priority=priority,
 		collapse_id=collapse_id,
+		mutable_content=mutable_content,
 		err_func=err_func,
 	)
 
@@ -277,6 +279,7 @@ def apns_send_bulk_message(
 	loc_key: str = None,
 	priority: int = None,
 	collapse_id: str = None,
+	mutable_content: int = None,
 	err_func: ErrFunc = None,
 ):
 	"""
@@ -311,6 +314,7 @@ def apns_send_bulk_message(
 			loc_key=loc_key,
 			priority=priority,
 			collapse_id=collapse_id,
+			mutable_content=mutable_content,
 			err_func=err_func,
 		))
 
@@ -355,11 +359,16 @@ async def _send_bulk_request(
 	loc_key: str = None,
 	priority: int = None,
 	collapse_id: str = None,
+	mutable_content: str = None,
 	err_func: ErrFunc = None,
 ):
 	client = _create_client(
 		creds=creds, application_id=application_id, topic=topic, err_func=err_func
 	)
+
+	aps_kwargs = {}
+	if mutable_content:
+		aps_kwargs["mutable-content"] = mutable_content
 
 	requests = [_create_notification_request_from_args(
 		registration_id,
@@ -372,6 +381,7 @@ async def _send_bulk_request(
 		loc_key=loc_key,
 		priority=priority,
 		collapse_id=collapse_id,
+		aps_kwargs=aps_kwargs
 	) for registration_id in registration_ids]
 
 	send_requests = [_send_request(client, request) for request in requests]

--- a/push_notifications/apns_async.py
+++ b/push_notifications/apns_async.py
@@ -239,8 +239,8 @@ def apns_send_message(
 	:param alert: The alert message to send
 	:param application_id: The application_id to use
 	:param creds: The credentials to use
- 	:param mutable_content: If True, enables the "mutable-content" flag in the payload.  
-                            This allows the app's Notification Service Extension to modify  
+ 	:param mutable_content: If True, enables the "mutable-content" flag in the payload.
+                            This allows the app's Notification Service Extension to modify
                             the notification before it is displayed.
 	"""
 	results = apns_send_bulk_message(
@@ -297,8 +297,8 @@ def apns_send_bulk_message(
 	:param alert: The alert message to send
 	:param application_id: The application_id to use
 	:param creds: The credentials to use
- 	:param mutable_content: If True, enables the "mutable-content" flag in the payload.  
-                            This allows the app's Notification Service Extension to modify  
+ 	:param mutable_content: If True, enables the "mutable-content" flag in the payload.
+                            This allows the app's Notification Service Extension to modify
                             the notification before it is displayed.
 	"""
 	try:

--- a/push_notifications/apns_async.py
+++ b/push_notifications/apns_async.py
@@ -222,7 +222,7 @@ def apns_send_message(
 	loc_key: str = None,
 	priority: int = None,
 	collapse_id: str = None,
-	mutable_content: int = None,
+	mutable_content: bool = False,
 	err_func: ErrFunc = None,
 ):
 	"""
@@ -239,6 +239,9 @@ def apns_send_message(
 	:param alert: The alert message to send
 	:param application_id: The application_id to use
 	:param creds: The credentials to use
+ 	:param mutable_content: If True, enables the "mutable-content" flag in the payload.  
+                            This allows the app's Notification Service Extension to modify  
+                            the notification before it is displayed.
 	"""
 	results = apns_send_bulk_message(
 		registration_ids=[registration_id],
@@ -279,7 +282,7 @@ def apns_send_bulk_message(
 	loc_key: str = None,
 	priority: int = None,
 	collapse_id: str = None,
-	mutable_content: int = None,
+	mutable_content: bool = False,
 	err_func: ErrFunc = None,
 ):
 	"""
@@ -294,6 +297,9 @@ def apns_send_bulk_message(
 	:param alert: The alert message to send
 	:param application_id: The application_id to use
 	:param creds: The credentials to use
+ 	:param mutable_content: If True, enables the "mutable-content" flag in the payload.  
+                            This allows the app's Notification Service Extension to modify  
+                            the notification before it is displayed.
 	"""
 	try:
 		topic = get_manager().get_apns_topic(application_id)
@@ -359,7 +365,7 @@ async def _send_bulk_request(
 	loc_key: str = None,
 	priority: int = None,
 	collapse_id: str = None,
-	mutable_content: str = None,
+	mutable_content: bool = False,
 	err_func: ErrFunc = None,
 ):
 	client = _create_client(

--- a/tests/test_apns_async_push_payload.py
+++ b/tests/test_apns_async_push_payload.py
@@ -181,6 +181,25 @@ class APNSAsyncPushPayloadTest(TestCase):
 			mock.ANY, result
 		)
 
+	@mock.patch("push_notifications.apns_async.APNs", autospec=True)
+	def test_push_payload_with_mutable_content(self, mock_apns):
+		apns_send_message(
+			"123",
+			"Hello world",
+			mutable_content=True,
+			creds=TokenCredentials(key="aaa", key_id="bbb", team_id="ccc"),
+			sound="chime",
+			extra={"custom_data": 12345},
+			expiration=int(time.time()) + 3,
+		)
+
+		args, kwargs = mock_apns.return_value.send_notification.call_args
+		req = args[0]
+
+		# Assertions
+		self.assertTrue("mutable-content" in req.message["aps"])
+		self.assertEqual(req.message["aps"]["mutable-content"], 1)  # APNs expects 1 for True
+
 	# def test_bad_priority(self):
 	# 	with mock.patch("apns2.credentials.init_context"):
 	# 		with mock.patch("apns2.client.APNsClient.connect"):


### PR DESCRIPTION
Re-do of #745 

Changes in the #745 was https://github.com/jazzband/django-push-notifications/commit/314a48410362f18f766608753a93248f7fc0eba6

This PR introduces support for the mutable_content property in the aioapns library, which was previously available only in apns2. The mutable_content property allows notifications to be modified by a Notification Service Extension before being delivered to the user.

This is related to https://github.com/jazzband/django-push-notifications/issues/320 and https://github.com/jazzband/django-push-notifications/pull/350.
Earlier support was available in the apns.py file, now added to apns_async.py.