### PR TITLE
Add support for `content_available` for apns async

### DIFF
--- a/push_notifications/apns_async.py
+++ b/push_notifications/apns_async.py
@@ -214,7 +214,7 @@ def apns_send_message(
 	topic: str = None,
 	badge: int = None,
 	sound: str = None,
-	content_available: bool | int = None,
+	content_available: bool = None,
 	extra: dict = {},
 	expiration: int = None,
 	thread_id: str = None,
@@ -246,7 +246,7 @@ def apns_send_message(
 	                 This should match a category identifier defined in the app's
 	                 Notification Content Extension or UNNotificationCategory configuration.
 	                 It allows the app to display custom actions with the notification.
-	:param content_available: If True or 1 the `content-available` flag will be set to 1, allowing the app to be woken up in the background
+	:param content_available: If True the `content-available` flag will be set to 1, allowing the app to be woken up in the background
 	"""
 	results = apns_send_bulk_message(
 		registration_ids=[registration_id],
@@ -283,7 +283,7 @@ def apns_send_bulk_message(
 	topic: str = None,
 	badge: int = None,
 	sound: str = None,
-	content_available: bool | int = None,
+	content_available: bool = None,
 	extra: dict = {},
 	expiration: int = None,
 	thread_id: str = None,
@@ -313,7 +313,7 @@ def apns_send_bulk_message(
 	                 This should match a category identifier defined in the app's
 	                 Notification Content Extension or UNNotificationCategory configuration.
 	                 It allows the app to display custom actions with the notification.
-	:param content_available: If True or 1 the `content-available` flag will be set to 1, allowing the app to be woken up in the background
+	:param content_available: If True the `content-available` flag will be set to 1, allowing the app to be woken up in the background
 	"""
 	try:
 		topic = get_manager().get_apns_topic(application_id)
@@ -380,7 +380,7 @@ async def _send_bulk_request(
 	topic: str = None,
 	badge: int = None,
 	sound: str = None,
-	content_available: bool | int = None,
+	content_available: bool = None,
 	extra: dict = {},
 	expiration: int = None,
 	thread_id: str = None,
@@ -401,11 +401,8 @@ async def _send_bulk_request(
 	if category:
 		aps_kwargs["category"] = category
 
-	if content_available is not None:
-		if isinstance(content_available, bool):
-			aps_kwargs["content-available"] = int(content_available)
-		else:
-			aps_kwargs["content-available"] = content_available
+	if content_available:
+		aps_kwargs["content-available"] = 1
 
 	requests = [
 		_create_notification_request_from_args(

--- a/tests/test_apns_async_push_payload.py
+++ b/tests/test_apns_async_push_payload.py
@@ -260,4 +260,3 @@ class APNSAsyncPushPayloadTest(TestCase):
 
 		assert "content-available" in req.message["aps"]
 		assert req.message["aps"]["content-available"] == 5
-

--- a/tests/test_apns_async_push_payload.py
+++ b/tests/test_apns_async_push_payload.py
@@ -259,16 +259,14 @@ class APNSAsyncPushPayloadTest(TestCase):
 		args, kwargs = mock_apns.return_value.send_notification.call_args
 		req = args[0]
 
-		assert "content-available" in req.message["aps"]
-		assert req.message["aps"]["content-available"] == 0
+		assert "content-available" not in req.message["aps"]
 
 
 	@mock.patch("push_notifications.apns_async.APNs", autospec=True)
-	def test_push_payload_with_content_available_int(self, mock_apns):
+	def test_push_payload_with_content_available_not_set(self, mock_apns):
 		apns_send_message(
 			"123",
 			"Hello world",
-			content_available=5,
 			creds=TokenCredentials(key="aaa", key_id="bbb", team_id="ccc"),
 			extra={"custom_data": 12345},
 			expiration=int(time.time()) + 3,
@@ -277,5 +275,4 @@ class APNSAsyncPushPayloadTest(TestCase):
 		args, kwargs = mock_apns.return_value.send_notification.call_args
 		req = args[0]
 
-		assert "content-available" in req.message["aps"]
-		assert req.message["aps"]["content-available"] == 5
+		assert "content-available" not in req.message["aps"]

--- a/tests/test_apns_async_push_payload.py
+++ b/tests/test_apns_async_push_payload.py
@@ -207,3 +207,57 @@ class APNSAsyncPushPayloadTest(TestCase):
 	# 				self.assertRaises(APNSUnsupportedPriority, _apns_send, "123",
 	# 				 "_" * 2049, priority=24)
 	# 			s.assert_has_calls([])
+
+	@mock.patch("push_notifications.apns_async.APNs", autospec=True)
+	def test_push_payload_with_content_available_bool_true(self, mock_apns):
+		apns_send_message(
+			"123",
+			"Hello world",
+			content_available=True,
+			creds=TokenCredentials(key="aaa", key_id="bbb", team_id="ccc"),
+			extra={"custom_data": 12345},
+			expiration=int(time.time()) + 3,
+		)
+
+		args, kwargs = mock_apns.return_value.send_notification.call_args
+		req = args[0]
+
+		assert "content-available" in req.message["aps"]
+		assert req.message["aps"]["content-available"] == 1
+
+
+	@mock.patch("push_notifications.apns_async.APNs", autospec=True)
+	def test_push_payload_with_content_available_bool_false(self, mock_apns):
+		apns_send_message(
+			"123",
+			"Hello world",
+			content_available=False,
+			creds=TokenCredentials(key="aaa", key_id="bbb", team_id="ccc"),
+			extra={"custom_data": 12345},
+			expiration=int(time.time()) + 3,
+		)
+
+		args, kwargs = mock_apns.return_value.send_notification.call_args
+		req = args[0]
+
+		assert "content-available" in req.message["aps"]
+		assert req.message["aps"]["content-available"] == 0
+
+
+	@mock.patch("push_notifications.apns_async.APNs", autospec=True)
+	def test_push_payload_with_content_available_int(self, mock_apns):
+		apns_send_message(
+			"123",
+			"Hello world",
+			content_available=5,
+			creds=TokenCredentials(key="aaa", key_id="bbb", team_id="ccc"),
+			extra={"custom_data": 12345},
+			expiration=int(time.time()) + 3,
+		)
+
+		args, kwargs = mock_apns.return_value.send_notification.call_args
+		req = args[0]
+
+		assert "content-available" in req.message["aps"]
+		assert req.message["aps"]["content-available"] == 5
+


### PR DESCRIPTION
- add `content_available` argument for async version of apns. Argument is sent as `content-available` to apns
- add tests for `content_available`
- format `apns_async.py`


(similar to #760)