### PR TITLE
Pin `aioapns` Dependency to `<4.0` to Prevent Breaking Changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,10 +43,10 @@ APNS =
 
 WP = pywebpush>=1.3.0
 
-apns-async = aioapns>=3.1
+apns-async = aioapns>=3.1,<4.0
 
 FCM = firebase-admin>=6.2
-APNS_ASYNC = aioapns>=3.1
+APNS_ASYNC = aioapns>=3.1,<4.0
 
 
 [options.packages.find]


### PR DESCRIPTION
This PR pins the `aioapns` dependency to versions `>=3.1,<4.0` in `setup.cfg` to avoid breaking changes introduced in `aioapns` 4.0.

The `APNsKeyConnectionPool` in `aioapns` 4.x expects a `key` string instead of a `key_path`, which would currently break existing integrations.

For now, pinning ensures stability and compatibility. A follow-up PR will handle the upgrade to support the newer API when ready.

Fixes: #766
