### PR TITLE
Add explicit Django AppConfig to set default_auto_field

### DIFF
--- a/push_notifications/apps.py
+++ b/push_notifications/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class PushNotificationsConfig(AppConfig):
+	name = "push_notifications"
+	default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Django projects might set `DEFAULT_AUTO_FIELD` to different values than `AutoField`.
In fact modern Django versions generate a settings.py file that uses `BigAutoField` by default.
The result is that when using this library in such a project, `makemigrations` will always attempt to create migrations for push_notification's models.

By adding an explicit `AppConfig`, Django knows that this application uses `AutoField`, regardless of the `DEFAULT_AUTO_FIELD` setting.

See:
- https://docs.djangoproject.com/en/5.2/ref/applications/#django.apps.AppConfig.default_auto_field
- https://docs.djangoproject.com/en/5.2/ref/applications/#configuring-applications

Fixes https://github.com/jazzband/django-push-notifications/issues/662
