### PR TITLE
Removed by mistake [b7195217f567be6185bfbb132059d94402e59eae]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ For WNS, you need both the ``WNS_PACKAGE_SECURITY_KEY`` and the ``WNS_SECRET_KEY
 - ``WP_PRIVATE_KEY``: Absolute path to your private certificate file: os.path.join(BASE_DIR, "private_key.pem")
 - ``WP_CLAIMS``: Dictionary with default value for the sub, (subject), sent to the webpush service, This would be used by the service if they needed to reach out to you (the sender). Could be a url or mailto e.g. {'sub': "mailto:development@example.com"}.
 - ``WP_ERROR_TIMEOUT``: The timeout on WebPush POSTs. (Optional)
+- ``WP_POST_URL``: A dictionary (key per browser supported) with the full url that webpush notifications will be POSTed to. (Optional)
 
 For more information about how to configure WebPush, see `docs/WebPush <https://github.com/jazzband/django-push-notifications/blob/master/docs/WebPush.rst>`_.
 


### PR DESCRIPTION
I think the next line was removed by error in this commit [b7195217f567be6185bfbb132059d94402e59eae]. Because WP_POST_URL is still a valid setting.