### PR TITLE
Fix webpush API

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -207,6 +207,7 @@ class WNSDeviceAuthorizedViewSet(AuthorizedMixin, WNSDeviceViewSet):
 class WebPushDeviceViewSet(DeviceViewSetMixin, ModelViewSet):
 	queryset = WebPushDevice.objects.all()
 	serializer_class = WebPushDeviceSerializer
+	lookup_value_regex = '.+'
 
 
 class WebPushDeviceAuthorizedViewSet(AuthorizedMixin, WebPushDeviceViewSet):


### PR DESCRIPTION
When registering a Web Push endpoint in the backend, it is essential to save the complete endpoint URL provided by the browser instead of just the token or identifier. This is because the full URL includes not only the device identifier but also the specific push service host, path and query parameters necessary for proper authentication and message delivery. These can change over time, storing only the token or a partial value risks losing the ability to send reliable and secure notifications, thus affecting the overall stability of the push notification system.

Therefore, the lookup_value_regex should allow for almost any character, as the value is sent from the frontend using encodeURIComponent, and URLs tend to be very complex and diverse.