### PR TITLE
Add support for py312 py313

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ classifiers =
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
+	Programming Language :: Python :: 3.13
 	Topic :: Internet :: WWW/HTTP
 	Topic :: System :: Networking
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ python =
     3.9: py39, flake8
 	3.10: py310
 	3.11: py311
+	3.12: py312
+	3.13: py313
 
 [gh-actions:env]
 DJANGO =
@@ -45,7 +47,7 @@ deps =
 	dj405: Django>=4.0.5,<4.1
 	dj42: Django>=4.2,<4.3
     py{36,37,38,39}: apns2
-    py{310,311}: aioapns>=3.1,<3.2
+    py{310,311,312,313}: aioapns>=3.1,<3.2
 
 [testenv:flake8]
 commands = flake8 --exit-zero


### PR DESCRIPTION
This change here documents the support for Python 3.11+, while fixing the broken pipeline due to the deprecated support for `Ubuntu 20.04` runners.