### PR TITLE
Add type anotation to methods and functions

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -14,9 +14,10 @@ from apns2 import payload as apns2_payload
 from . import models
 from .conf import get_manager
 from .exceptions import APNSError, APNSUnsupportedPriority, APNSServerError
+from typing import Any, Callable
 
 
-def _apns_create_socket(creds=None, application_id=None):
+def _apns_create_socket(creds=None, application_id=None) -> apns2_client.APNsClient:
 	if creds is None:
 		if not get_manager().has_auth_token_creds(application_id):
 			cert = get_manager().get_apns_certificate(application_id)
@@ -39,9 +40,20 @@ def _apns_create_socket(creds=None, application_id=None):
 
 
 def _apns_prepare(
-	token, alert, application_id=None, badge=None, sound=None, category=None,
-	content_available=False, action_loc_key=None, loc_key=None, loc_args=[],
-	extra={}, mutable_content=False, thread_id=None, url_args=None):
+	token: str, 
+	alert: str | dict[str, Any] | None, 
+	application_id: str | None = None, 
+	badge: int | Callable | None = None, 
+	sound: str | None = None, 
+	category: str | None = None,
+	content_available: bool = False, 
+	action_loc_key: str | None = None, 
+	loc_key: str | None = None, 
+	loc_args: str | None = [],
+	extra: dict[str, Any] = {}, 
+	mutable_content: bool = False, 
+	thread_id: str | None = None, 
+	url_args: list[str] | None = None) -> apns2_payload.Payload:
 		if action_loc_key or loc_key or loc_args:
 			apns2_alert = apns2_payload.PayloadAlert(
 				body=alert if alert else {}, body_localized_key=loc_key,
@@ -59,8 +71,13 @@ def _apns_prepare(
 
 
 def _apns_send(
-	registration_id, alert, batch=False, application_id=None, creds=None, **kwargs
-):
+	registration_id: str | list[str], 
+	alert: str | dict[str, Any] | None, 
+	batch: bool = False, 
+	application_id: str | None = None, 
+	creds: apns2_credentials.Credentials | None = None, 
+	**kwargs: Any
+) -> dict[str, str] | None:
 	client = _apns_create_socket(creds=creds, application_id=application_id)
 
 	notification_kwargs = {}
@@ -95,9 +112,16 @@ def _apns_send(
 		get_manager().get_apns_topic(application_id=application_id),
 		**notification_kwargs
 	)
+	return None
 
 
-def apns_send_message(registration_id, alert, application_id=None, creds=None, **kwargs):
+def apns_send_message(
+	registration_id: str, 
+	alert: str | dict[str, Any] | None, 
+	application_id: str | None = None, 
+	creds: apns2_credentials.Credentials | None = None, 
+	**kwargs: Any
+) -> None:
 	"""
 	Sends an APNS notification to a single registration_id.
 	This will send the notification as form data.
@@ -122,8 +146,12 @@ def apns_send_message(registration_id, alert, application_id=None, creds=None, *
 
 
 def apns_send_bulk_message(
-	registration_ids, alert, application_id=None, creds=None, **kwargs
-):
+	registration_ids: list[str], 
+	alert: str | dict[str, Any] | None, 
+	application_id: str | None = None, 
+	creds: apns2_credentials.Credentials | None = None, 
+	**kwargs: Any
+) -> dict[str, str]:
 	"""
 	Sends an APNS notification to one or more registration_ids.
 	The registration_ids argument needs to be a list.

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -40,19 +40,19 @@ def _apns_create_socket(creds=None, application_id=None) -> apns2_client.APNsCli
 
 
 def _apns_prepare(
-	token: str, 
-	alert: str | dict[str, Any] | None, 
-	application_id: str | None = None, 
-	badge: int | Callable | None = None, 
-	sound: str | None = None, 
+	token: str,
+	alert: str | dict[str, Any] | None,
+	application_id: str | None = None,
+	badge: int | Callable | None = None,
+	sound: str | None = None,
 	category: str | None = None,
-	content_available: bool = False, 
-	action_loc_key: str | None = None, 
-	loc_key: str | None = None, 
+	content_available: bool = False,
+	action_loc_key: str | None = None,
+	loc_key: str | None = None,
 	loc_args: str | None = [],
-	extra: dict[str, Any] = {}, 
-	mutable_content: bool = False, 
-	thread_id: str | None = None, 
+	extra: dict[str, Any] = {},
+	mutable_content: bool = False,
+	thread_id: str | None = None,
 	url_args: list[str] | None = None) -> apns2_payload.Payload:
 		if action_loc_key or loc_key or loc_args:
 			apns2_alert = apns2_payload.PayloadAlert(
@@ -71,11 +71,11 @@ def _apns_prepare(
 
 
 def _apns_send(
-	registration_id: str | list[str], 
-	alert: str | dict[str, Any] | None, 
-	batch: bool = False, 
-	application_id: str | None = None, 
-	creds: apns2_credentials.Credentials | None = None, 
+	registration_id: str | list[str],
+	alert: str | dict[str, Any] | None,
+	batch: bool = False,
+	application_id: str | None = None,
+	creds: apns2_credentials.Credentials | None = None,
 	**kwargs: Any
 ) -> dict[str, str] | None:
 	client = _apns_create_socket(creds=creds, application_id=application_id)
@@ -116,10 +116,10 @@ def _apns_send(
 
 
 def apns_send_message(
-	registration_id: str, 
-	alert: str | dict[str, Any] | None, 
-	application_id: str | None = None, 
-	creds: apns2_credentials.Credentials | None = None, 
+	registration_id: str,
+	alert: str | dict[str, Any] | None,
+	application_id: str | None = None,
+	creds: apns2_credentials.Credentials | None = None,
 	**kwargs: Any
 ) -> None:
 	"""
@@ -146,10 +146,10 @@ def apns_send_message(
 
 
 def apns_send_bulk_message(
-	registration_ids: list[str], 
-	alert: str | dict[str, Any] | None, 
-	application_id: str | None = None, 
-	creds: apns2_credentials.Credentials | None = None, 
+	registration_ids: list[str],
+	alert: str | dict[str, Any] | None,
+	application_id: str | None = None,
+	creds: apns2_credentials.Credentials | None = None,
 	**kwargs: Any
 ) -> dict[str, str]:
 	"""

--- a/push_notifications/conf/__init__.py
+++ b/push_notifications/conf/__init__.py
@@ -8,8 +8,7 @@ from .legacy import LegacyConfig  # noqa: F401
 
 manager = None
 
-
-def get_manager(reload=False):
+def get_manager(reload: bool = False) -> object:
 	global manager
 
 	if not manager or reload is True:

--- a/push_notifications/conf/app.py
+++ b/push_notifications/conf/app.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
-
-from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+from typing import Any
+from push_notifications.settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 from .base import BaseConfig, check_apns_certificate
 
 
@@ -71,7 +71,7 @@ class AppConfig(BaseConfig):
 	Supports any number of push notification enabled applications.
 	"""
 
-	def __init__(self, settings=None):
+	def __init__(self, settings: dict[str, Any] = None) -> None:
 		# supports overriding the settings to be loaded. Will load from ..settings by default.
 		self._settings = settings or SETTINGS
 
@@ -81,14 +81,14 @@ class AppConfig(BaseConfig):
 		# validate application configurations
 		self._validate_applications(self._settings["APPLICATIONS"])
 
-	def _validate_applications(self, apps):
+	def _validate_applications(self, apps: dict[str, Any]) -> None:
 		"""Validate the application collection"""
 		for application_id, application_config in apps.items():
 			self._validate_config(application_id, application_config)
 
 			application_config["APPLICATION_ID"] = application_id
 
-	def _validate_config(self, application_id, application_config):
+	def _validate_config(self, application_id: str, application_config: dict[str, Any]) -> None:
 		platform = application_config.get("PLATFORM", None)
 
 		# platform is not present
@@ -123,7 +123,7 @@ class AppConfig(BaseConfig):
 				)
 			)
 
-	def _validate_apns_config(self, application_id, application_config):
+	def _validate_apns_config(self, application_id: str, application_config: dict[str, Any]) -> None:
 		allowed = REQUIRED_SETTINGS + OPTIONAL_SETTINGS + \
 			APNS_AUTH_CREDS_REQUIRED + \
 			APNS_AUTH_CREDS_OPTIONAL + \
@@ -166,7 +166,7 @@ class AppConfig(BaseConfig):
 		application_config.setdefault("USE_ALTERNATIVE_PORT", False)
 		application_config.setdefault("TOPIC", None)
 
-	def _validate_apns_certificate(self, certfile):
+	def _validate_apns_certificate(self, certfile: str) -> None:
 		"""Validate the APNS certificate at startup."""
 
 		try:
@@ -178,7 +178,7 @@ class AppConfig(BaseConfig):
 				"The APNS certificate file at {!r} is not readable: {}".format(certfile, e)
 			)
 
-	def _validate_fcm_config(self, application_id, application_config):
+	def _validate_fcm_config(self, application_id: str, application_config: dict[str, Any]) -> None:
 		allowed = (
 			REQUIRED_SETTINGS + OPTIONAL_SETTINGS + FCM_REQUIRED_SETTINGS + FCM_OPTIONAL_SETTINGS
 		)
@@ -191,7 +191,7 @@ class AppConfig(BaseConfig):
 		application_config.setdefault("FIREBASE_APP", None)
 		application_config.setdefault("MAX_RECIPIENTS", 1000)
 
-	def _validate_wns_config(self, application_id, application_config):
+	def _validate_wns_config(self, application_id: str, application_config: dict[str, Any]) -> None:
 		allowed = (
 			REQUIRED_SETTINGS + OPTIONAL_SETTINGS + WNS_REQUIRED_SETTINGS + WNS_OPTIONAL_SETTINGS
 		)
@@ -203,7 +203,7 @@ class AppConfig(BaseConfig):
 
 		application_config.setdefault("WNS_ACCESS_URL", "https://login.live.com/accesstoken.srf")
 
-	def _validate_wp_config(self, application_id, application_config):
+	def _validate_wp_config(self, application_id: str, application_config: dict[str, Any]) -> None:
 		allowed = (
 			REQUIRED_SETTINGS + OPTIONAL_SETTINGS + WP_REQUIRED_SETTINGS + WP_OPTIONAL_SETTINGS
 		)
@@ -219,7 +219,7 @@ class AppConfig(BaseConfig):
 			"FIREFOX": "https://updates.push.services.mozilla.com/wpush/v2",
 		})
 
-	def _validate_allowed_settings(self, application_id, application_config, allowed_settings):
+	def _validate_allowed_settings(self, application_id: str, application_config: dict[str, Any], allowed_settings: list[str]) -> None:
 		"""Confirm only allowed settings are present."""
 
 		for setting_key in application_config.keys():
@@ -231,9 +231,9 @@ class AppConfig(BaseConfig):
 				)
 
 	def _validate_required_settings(
-		self, application_id, application_config, required_settings,
-		should_throw=True
-	):
+		self, application_id: str, application_config: dict[str, Any], required_settings: list[str],
+		should_throw: bool = True
+	) -> bool:
 		"""All required keys must be present"""
 
 		for setting_key in required_settings:
@@ -248,7 +248,7 @@ class AppConfig(BaseConfig):
 					return False
 		return True
 
-	def _get_application_settings(self, application_id, platform, settings_key):
+	def _get_application_settings(self, application_id: str, platform: str, settings_key: str) -> Any:
 		"""
 		Walks through PUSH_NOTIFICATIONS_SETTINGS to find the correct setting value
 		or raises ImproperlyConfigured.
@@ -287,16 +287,16 @@ class AppConfig(BaseConfig):
 
 		return app_config.get(settings_key)
 
-	def get_firebase_app(self, application_id=None):
+	def get_firebase_app(self, application_id: str = None) -> Any:
 		return self._get_application_settings(application_id, "FCM", "FIREBASE_APP")
 
-	def has_auth_token_creds(self, application_id=None):
+	def has_auth_token_creds(self, application_id: str = None) -> bool:
 		return self.has_token_creds
 
-	def get_max_recipients(self, application_id=None):
+	def get_max_recipients(self, application_id: str = None) -> int:
 		return self._get_application_settings(application_id, "FCM", "MAX_RECIPIENTS")
 
-	def get_apns_certificate(self, application_id=None):
+	def get_apns_certificate(self, application_id: str = None) -> str:
 		r = self._get_application_settings(application_id, "APNS", "CERTIFICATE")
 		if not isinstance(r, str):
 			# probably the (Django) file, and file path should be got
@@ -311,41 +311,41 @@ class AppConfig(BaseConfig):
 				)
 		return r
 
-	def get_apns_auth_creds(self, application_id=None):
+	def get_apns_auth_creds(self, application_id: str = None) -> tuple[str, str, str]:
 		return \
 		(self._get_apns_auth_key_path(application_id),
 			self._get_apns_auth_key_id(application_id),
 			self._get_apns_team_id(application_id))
 
-	def _get_apns_auth_key_path(self, application_id=None):
+	def _get_apns_auth_key_path(self, application_id: str = None) -> str:
 		return self._get_application_settings(application_id, "APNS", "AUTH_KEY_PATH")
 
-	def _get_apns_auth_key_id(self, application_id=None):
+	def _get_apns_auth_key_id(self, application_id: str = None) -> str:
 		return self._get_application_settings(application_id, "APNS", "AUTH_KEY_ID")
 
-	def _get_apns_team_id(self, application_id=None):
+	def _get_apns_team_id(self, application_id: str = None) -> str:
 		return self._get_application_settings(application_id, "APNS", "TEAM_ID")
 
-	def get_apns_use_sandbox(self, application_id=None):
+	def get_apns_use_sandbox(self, application_id: str = None) -> bool:
 		return self._get_application_settings(application_id, "APNS", "USE_SANDBOX")
 
-	def get_apns_use_alternative_port(self, application_id=None):
+	def get_apns_use_alternative_port(self, application_id: str = None) -> bool:
 		return self._get_application_settings(application_id, "APNS", "USE_ALTERNATIVE_PORT")
 
-	def get_apns_topic(self, application_id=None):
+	def get_apns_topic(self, application_id: str = None) -> str:
 		return self._get_application_settings(application_id, "APNS", "TOPIC")
 
-	def get_wns_package_security_id(self, application_id=None):
+	def get_wns_package_security_id(self, application_id: str = None) -> str:
 		return self._get_application_settings(application_id, "WNS", "PACKAGE_SECURITY_ID")
 
-	def get_wns_secret_key(self, application_id=None):
+	def get_wns_secret_key(self, application_id: str = None) -> str:
 		return self._get_application_settings(application_id, "WNS", "SECRET_KEY")
 
-	def get_wp_post_url(self, application_id, browser):
+	def get_wp_post_url(self, application_id: str, browser: str) -> str:
 		return self._get_application_settings(application_id, "WP", "POST_URL")[browser]
 
-	def get_wp_private_key(self, application_id=None):
+	def get_wp_private_key(self, application_id: str = None) -> str:
 		return self._get_application_settings(application_id, "WP", "PRIVATE_KEY")
 
-	def get_wp_claims(self, application_id=None):
+	def get_wp_claims(self, application_id: str = None) -> dict[str, Any]:
 		return self._get_application_settings(application_id, "WP", "CLAIMS")

--- a/push_notifications/conf/base.py
+++ b/push_notifications/conf/base.py
@@ -1,36 +1,36 @@
 from django.core.exceptions import ImproperlyConfigured
-
+from typing import Any
 
 class BaseConfig:
 
-	def get_firebase_app(self, application_id=None):
+	def get_firebase_app(self, application_id: str | None = None) -> object:
 		raise NotImplementedError
 
-	def has_auth_token_creds(self, application_id=None):
+	def has_auth_token_creds(self, application_id: str | None = None) -> bool:
 		raise NotImplementedError
 
-	def get_apns_certificate(self, application_id=None):
+	def get_apns_certificate(self, application_id: str | None = None) -> str:
 		raise NotImplementedError
 
-	def get_apns_auth_creds(self, application_id=None):
+	def get_apns_auth_creds(self, application_id: str | None = None) -> dict[str, Any]:
 		raise NotImplementedError
 
-	def get_apns_use_sandbox(self, application_id=None):
+	def get_apns_use_sandbox(self, application_id: str | None = None) -> bool:
 		raise NotImplementedError
 
-	def get_apns_use_alternative_port(self, application_id=None):
+	def get_apns_use_alternative_port(self, application_id: str | None = None) -> bool:
 		raise NotImplementedError
 
-	def get_wns_package_security_id(self, application_id=None):
+	def get_wns_package_security_id(self, application_id: str | None = None) -> str:
 		raise NotImplementedError
 
-	def get_wns_secret_key(self, application_id=None):
+	def get_wns_secret_key(self, application_id: str | None = None) -> str:
 		raise NotImplementedError
 
-	def get_max_recipients(self, application_id=None):
+	def get_max_recipients(self, application_id: str | None = None) -> int:
 		raise NotImplementedError
 
-	def get_applications(self):
+	def get_applications(self) -> list[str]:
 		"""Returns a collection containing the configured applications."""
 
 		raise NotImplementedError
@@ -38,7 +38,7 @@ class BaseConfig:
 
 # This works for both the certificate and the auth key (since that's just
 # a certificate).
-def check_apns_certificate(ss):
+def check_apns_certificate(ss: str) -> None:
 	mode = "start"
 	for s in ss.split("\n"):
 		if mode == "start":

--- a/push_notifications/conf/legacy.py
+++ b/push_notifications/conf/legacy.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
-
-from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+from typing import Any
+from push_notifications.settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 from .base import BaseConfig
 
 
@@ -16,7 +16,7 @@ class empty:
 class LegacyConfig(BaseConfig):
 	msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
 
-	def _get_application_settings(self, application_id, settings_key, error_message):
+	def _get_application_settings(self, application_id: str | None = None, settings_key: str | None = None, error_message: str | None = None) -> Any:
 		"""Legacy behaviour"""
 
 		if not application_id:
@@ -31,21 +31,21 @@ class LegacyConfig(BaseConfig):
 			)
 			raise ImproperlyConfigured(msg)
 
-	def get_firebase_app(self, application_id=None):
+	def get_firebase_app(self, application_id: str | None = None) -> Any:
 		key = "FIREBASE_APP"
 		msg = (
 			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through FCM.'.format(key)
 		)
 		return self._get_application_settings(application_id, key, msg)
 
-	def get_max_recipients(self, application_id=None):
+	def get_max_recipients(self, application_id: str = None) -> int:
 		key = "FCM_MAX_RECIPIENTS"
 		msg = (
 			'Set PUSH_NOTIFICATIONS_SETTINGS["{}"] to send messages through FCM.'.format(key)
 		)
 		return self._get_application_settings(application_id, key, msg)
 
-	def has_auth_token_creds(self, application_id=None):
+	def has_auth_token_creds(self, application_id: str | None = None) -> bool:
 		try:
 			self._get_apns_auth_key(application_id)
 			self._get_apns_auth_key_id(application_id)
@@ -55,7 +55,7 @@ class LegacyConfig(BaseConfig):
 
 		return True
 
-	def get_apns_certificate(self, application_id=None):
+	def get_apns_certificate(self, application_id: str | None = None) -> str:
 		r = self._get_application_settings(
 			application_id, "APNS_CERTIFICATE",
 			"You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
@@ -74,57 +74,57 @@ class LegacyConfig(BaseConfig):
 				raise ImproperlyConfigured(msg)
 		return r
 
-	def get_apns_auth_creds(self, application_id=None):
+	def get_apns_auth_creds(self, application_id: str | None = None) -> tuple[Any, Any, Any]:
 		return (
 			self._get_apns_auth_key(application_id),
 			self._get_apns_auth_key_id(application_id),
 			self._get_apns_team_id(application_id))
 
-	def _get_apns_auth_key(self, application_id=None):
+	def _get_apns_auth_key(self, application_id: str | None = None) -> str:
 		return self._get_application_settings(application_id, "APNS_AUTH_KEY_PATH", self.msg)
 
-	def _get_apns_team_id(self, application_id=None):
+	def _get_apns_team_id(self, application_id: str | None = None) -> str:
 		return self._get_application_settings(application_id, "APNS_TEAM_ID", self.msg)
 
-	def _get_apns_auth_key_id(self, application_id=None):
+	def _get_apns_auth_key_id(self, application_id: str | None = None) -> str:
 		return self._get_application_settings(application_id, "APNS_AUTH_KEY_ID", self.msg)
 
-	def get_apns_use_sandbox(self, application_id=None):
+	def get_apns_use_sandbox(self, application_id: str | None = None) -> bool:
 		return self._get_application_settings(application_id, "APNS_USE_SANDBOX", self.msg)
 
-	def get_apns_use_alternative_port(self, application_id=None):
+	def get_apns_use_alternative_port(self, application_id: str | None = None) -> bool:
 		return self._get_application_settings(application_id, "APNS_USE_ALTERNATIVE_PORT", self.msg)
 
-	def get_apns_topic(self, application_id=None):
+	def get_apns_topic(self, application_id: str | None = None) -> str:
 		return self._get_application_settings(application_id, "APNS_TOPIC", self.msg)
 
-	def get_apns_host(self, application_id=None):
+	def get_apns_host(self, application_id: str | None = None) -> str:
 		return self._get_application_settings(application_id, "APNS_HOST", self.msg)
 
-	def get_apns_port(self, application_id=None):
+	def get_apns_port(self, application_id: str | None = None) -> int:
 		return self._get_application_settings(application_id, "APNS_PORT", self.msg)
 
-	def get_apns_feedback_host(self, application_id=None):
+	def get_apns_feedback_host(self, application_id: str | None = None) -> str:
 		return self._get_application_settings(application_id, "APNS_FEEDBACK_HOST", self.msg)
 
-	def get_apns_feedback_port(self, application_id=None):
+	def get_apns_feedback_port(self, application_id: str | None = None) -> int:
 		return self._get_application_settings(application_id, "APNS_FEEDBACK_PORT", self.msg)
 
-	def get_wns_package_security_id(self, application_id=None):
+	def get_wns_package_security_id(self, application_id: str | None = None) -> str:
 		return self._get_application_settings(application_id, "WNS_PACKAGE_SECURITY_ID", self.msg)
 
-	def get_wns_secret_key(self, application_id=None):
+	def get_wns_secret_key(self, application_id: str | None = None) -> str:
 		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
 		return self._get_application_settings(application_id, "WNS_SECRET_KEY", msg)
 
-	def get_wp_post_url(self, application_id, browser):
+	def get_wp_post_url(self, application_id: str, browser: str) -> str:
 		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
 		return self._get_application_settings(application_id, "WP_POST_URL", msg)[browser]
 
-	def get_wp_private_key(self, application_id=None):
+	def get_wp_private_key(self, application_id: str | None = None) -> str:
 		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
 		return self._get_application_settings(application_id, "WP_PRIVATE_KEY", msg)
 
-	def get_wp_claims(self, application_id=None):
+	def get_wp_claims(self, application_id: str | None = None) -> dict[str, Any]:
 		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
 		return self._get_application_settings(application_id, "WP_CLAIMS", msg)

--- a/push_notifications/exceptions.py
+++ b/push_notifications/exceptions.py
@@ -1,5 +1,5 @@
 class NotificationError(Exception):
-	def __init__(self, message):
+	def __init__(self, message: str) -> None:
 		super().__init__(message)
 		self.message = message
 	pass
@@ -15,7 +15,7 @@ class APNSUnsupportedPriority(APNSError):
 
 
 class APNSServerError(APNSError):
-	def __init__(self, status):
+	def __init__(self, status: int) -> None:
 		super().__init__(status)
 		self.status = status
 

--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -1,6 +1,6 @@
 import re
 import struct
-
+from typing import Any
 from django import forms
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import connection, models
@@ -20,23 +20,23 @@ signed_integer_vendors = [
 ]
 
 
-def _using_signed_storage():
+def _using_signed_storage() -> bool:
 	return connection.vendor in signed_integer_vendors
 
 
-def _signed_to_unsigned_integer(value):
+def _signed_to_unsigned_integer(value: int) -> int:
 	return struct.unpack("Q", struct.pack("q", value))[0]
 
 
-def _unsigned_to_signed_integer(value):
+def _unsigned_to_signed_integer(value: int) -> int:
 	return struct.unpack("q", struct.pack("Q", value))[0]
 
 
-def _hex_string_to_unsigned_integer(value):
+def _hex_string_to_unsigned_integer(value: str) -> int:
 	return int(value, 16)
 
 
-def _unsigned_integer_to_hex_string(value):
+def _unsigned_integer_to_hex_string(value: int) -> str:
 	return hex(value).rstrip("L")
 
 
@@ -44,13 +44,13 @@ class HexadecimalField(forms.CharField):
 	"""
 	A form field that accepts only hexadecimal numbers
 	"""
-	def __init__(self, *args, **kwargs):
+	def __init__(self, *args: Any, **kwargs: Any) -> None:
 		self.default_validators = [
 			RegexValidator(hex_re, _("Enter a valid hexadecimal number"), "invalid")
 		]
 		super().__init__(*args, **kwargs)
 
-	def prepare_value(self, value):
+	def prepare_value(self, value: Any) -> Any:
 		# converts bigint from db to hex before it is displayed in admin
 		if value and not isinstance(value, str) \
 			and connection.vendor in ("mysql", "sqlite"):
@@ -76,7 +76,7 @@ class HexIntegerField(models.BigIntegerField):
 		MaxValueValidator(UNSIGNED_64BIT_INT_MAX_VALUE)
 	]
 
-	def db_type(self, connection):
+	def db_type(self, connection: Any) -> str:
 		if "mysql" == connection.vendor:
 			return "bigint unsigned"
 		elif "sqlite" == connection.vendor:
@@ -84,7 +84,7 @@ class HexIntegerField(models.BigIntegerField):
 		else:
 			return super().db_type(connection=connection)
 
-	def get_prep_value(self, value):
+	def get_prep_value(self, value: Any) -> Any:
 		""" Return the integer value to be stored from the hex string """
 		if value is None or value == "":
 			return None
@@ -94,7 +94,7 @@ class HexIntegerField(models.BigIntegerField):
 			value = _unsigned_to_signed_integer(value)
 		return value
 
-	def from_db_value(self, value, *args):
+	def from_db_value(self, value: Any, *args: Any) -> Any:
 		""" Return an unsigned int representation from all db backends """
 		if value is None:
 			return value
@@ -102,7 +102,7 @@ class HexIntegerField(models.BigIntegerField):
 			value = _signed_to_unsigned_integer(value)
 		return value
 
-	def to_python(self, value):
+	def to_python(self, value: Any) -> Any:
 		""" Return a str representation of the hexadecimal """
 		if isinstance(value, str):
 			return value
@@ -110,13 +110,13 @@ class HexIntegerField(models.BigIntegerField):
 			return value
 		return _unsigned_integer_to_hex_string(value)
 
-	def formfield(self, **kwargs):
+	def formfield(self, **kwargs: Any) -> forms.Field:
 		defaults = {"form_class": HexadecimalField}
 		defaults.update(kwargs)
 		# yes, that super call is right
 		return super(models.IntegerField, self).formfield(**defaults)
 
-	def run_validators(self, value):
+	def run_validators(self, value: str) -> None:
 		# make sure validation is performed on integer value not string value
 		value = _hex_string_to_unsigned_integer(value)
 		return super(models.BigIntegerField, self).run_validators(value)

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-
+from typing import Any
 from .fields import HexIntegerField
 from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 
@@ -42,7 +42,7 @@ class Device(models.Model):
 	class Meta:
 		abstract = True
 
-	def __str__(self):
+	def __str__(self) -> str:
 		return (
 			self.name or
 			str(self.device_id or "") or
@@ -51,12 +51,12 @@ class Device(models.Model):
 
 
 class GCMDeviceManager(models.Manager):
-	def get_queryset(self):
+	def get_queryset(self) -> "GCMDeviceQuerySet":
 		return GCMDeviceQuerySet(self.model)
 
 
 class GCMDeviceQuerySet(models.query.QuerySet):
-	def send_message(self, message, **kwargs):
+	def send_message(self, message: object, **kwargs: Any):
 		if self.exists():
 			from .gcm import dict_to_fcm_message, messaging
 			from .gcm import send_message as fcm_send_message
@@ -106,13 +106,13 @@ class GCMDevice(Device):
 	class Meta:
 		verbose_name = _("FCM device")
 
-	def send_message(self, message, **kwargs):
+	def send_message(self, message: object, **kwargs: Any) -> Any:
 		from .gcm import dict_to_fcm_message, messaging
 		from .gcm import send_message as fcm_send_message
 
 		# GCM is not supported.
 		if self.cloud_message_type == "GCM":
-			return
+			return None
 
 		if not isinstance(message, messaging.Message):
 			data = kwargs.pop("extra", {})
@@ -128,12 +128,12 @@ class GCMDevice(Device):
 
 
 class APNSDeviceManager(models.Manager):
-	def get_queryset(self):
+	def get_queryset(self) -> "APNSDeviceQuerySet":
 		return APNSDeviceQuerySet(self.model)
 
 
 class APNSDeviceQuerySet(models.query.QuerySet):
-	def send_message(self, message, creds=None, **kwargs):
+	def send_message(self, message: str, creds: dict[str, Any] | None = None, **kwargs: Any) -> list:
 		if self.exists():
 			try:
 				from .apns_async import apns_send_bulk_message
@@ -174,7 +174,7 @@ class APNSDevice(Device):
 	class Meta:
 		verbose_name = _("APNS device")
 
-	def send_message(self, message, creds=None, **kwargs):
+	def send_message(self, message: str, creds: dict[str, Any] | None = None, **kwargs: Any) -> Any:
 		try:
 			from .apns_async import apns_send_message
 		except ImportError:
@@ -189,12 +189,12 @@ class APNSDevice(Device):
 
 
 class WNSDeviceManager(models.Manager):
-	def get_queryset(self):
+	def get_queryset(self) -> "WebPushDeviceQuerySet":
 		return WNSDeviceQuerySet(self.model)
 
 
 class WNSDeviceQuerySet(models.query.QuerySet):
-	def send_message(self, message, **kwargs):
+	def send_message(self, message: str, **kwargs: Any) -> list:
 		from .wns import wns_send_bulk_message
 
 		app_ids = self.filter(active=True).order_by("application_id").values_list(
@@ -226,7 +226,7 @@ class WNSDevice(Device):
 	class Meta:
 		verbose_name = _("WNS device")
 
-	def send_message(self, message, **kwargs):
+	def send_message(self, message: str, **kwargs: Any) -> Any:
 		from .wns import wns_send_message
 
 		return wns_send_message(
@@ -236,12 +236,12 @@ class WNSDevice(Device):
 
 
 class WebPushDeviceManager(models.Manager):
-	def get_queryset(self):
+	def get_queryset(self) -> "WebPushDeviceQuerySet":
 		return WebPushDeviceQuerySet(self.model)
 
 
 class WebPushDeviceQuerySet(models.query.QuerySet):
-	def send_message(self, message, **kwargs):
+	def send_message(self, message: str, **kwargs: Any) -> list:
 		devices = self.filter(active=True).order_by("application_id").distinct()
 		res = []
 		for device in devices:
@@ -269,10 +269,10 @@ class WebPushDevice(Device):
 		verbose_name = _("WebPush device")
 
 	@property
-	def device_id(self):
+	def device_id(self) -> None:
 		return None
 
-	def send_message(self, message, **kwargs):
+	def send_message(self, message: str, **kwargs: Any) -> Any:
 		from .webpush import webpush_send_message
 
 		return webpush_send_message(self, message, **kwargs)

--- a/push_notifications/webpush.py
+++ b/push_notifications/webpush.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Any
 
 from pywebpush import WebPushException, webpush
 
@@ -6,7 +7,7 @@ from .conf import get_manager
 from .exceptions import WebPushError
 
 
-def get_subscription_info(application_id, uri, browser, auth, p256dh):
+def get_subscription_info(application_id: str, uri: str, browser: str, auth: str, p256dh: str) -> dict[str, Any]:
 	if uri.startswith("https://"):
 		endpoint = uri
 	else:
@@ -26,7 +27,7 @@ def get_subscription_info(application_id, uri, browser, auth, p256dh):
 	}
 
 
-def webpush_send_message(device, message, **kwargs):
+def webpush_send_message(device: Any, message: str, **kwargs: Any) -> dict[str, Any]:
 	subscription_info = get_subscription_info(
 		device.application_id, device.registration_id,
 		device.browser, device.auth, device.p256dh)

--- a/push_notifications/wns.py
+++ b/push_notifications/wns.py
@@ -9,7 +9,7 @@ import json
 import xml.etree.ElementTree as ET
 
 from django.core.exceptions import ImproperlyConfigured
-
+from typing import Any
 from .compat import HTTPError, Request, urlencode, urlopen
 from .conf import get_manager
 from .exceptions import NotificationError
@@ -28,7 +28,7 @@ class WNSNotificationResponseError(WNSError):
 	pass
 
 
-def _wns_authenticate(scope="notify.windows.com", application_id=None):
+def _wns_authenticate(scope: str = "notify.windows.com", application_id: str | None = None) -> str:
 	"""
 	Requests an Access token for WNS communication.
 
@@ -82,13 +82,13 @@ def _wns_authenticate(scope="notify.windows.com", application_id=None):
 	return access_token
 
 
-def _wns_send(uri, data, wns_type="wns/toast", application_id=None):
+def _wns_send(uri: str, data: str | bytes, wns_type: str = "wns/toast", application_id: str | None = None) -> str:
 	"""
 	Sends a notification data and authentication to WNS.
 
 	:param uri: str: The device's unique notification URI
 	:param data: dict: The notification data to be sent.
-	:return:
+	:return: str: The response from WNS server
 	"""
 	access_token = _wns_authenticate(application_id=application_id)
 
@@ -139,7 +139,7 @@ def _wns_send(uri, data, wns_type="wns/toast", application_id=None):
 	return response.read().decode("utf-8")
 
 
-def _wns_prepare_toast(data, **kwargs):
+def _wns_prepare_toast(data: dict[str, Any], **kwargs: Any) -> bytes:
 	"""
 	Creates the xml tree for a `toast` notification
 
@@ -150,7 +150,7 @@ def _wns_prepare_toast(data, **kwargs):
 		"image": ["src1", "src2"],
 	}
 
-	:return: str
+	:return: bytes
 	"""
 	root = ET.Element("toast")
 	visual = ET.SubElement(root, "visual")
@@ -170,8 +170,13 @@ def _wns_prepare_toast(data, **kwargs):
 
 
 def wns_send_message(
-	uri, message=None, xml_data=None, raw_data=None, application_id=None, **kwargs
-):
+	uri: str, 
+	message: str | dict[str, list[str]] = None, 
+	xml_data: dict[str, Any] = None, 
+	raw_data: str | bytes | None= None, 
+	application_id: str | None = None, 
+	**kwargs: Any
+) -> str:
 	"""
 	Sends a notification request to WNS.
 	There are four notification types that WNS can send: toast, tile, badge and raw.
@@ -235,8 +240,13 @@ def wns_send_message(
 
 
 def wns_send_bulk_message(
-	uri_list, message=None, xml_data=None, raw_data=None, application_id=None, **kwargs
-):
+	uri_list: list[str], 
+	message: str | dict[str, list[str]] | None = None, 
+	xml_data: dict[str, Any] | None = None, 
+	raw_data: str | bytes | None = None, 
+	application_id: str | None = None, 
+	**kwargs: Any
+) -> list[str]:
 	"""
 	WNS doesn't support bulk notification, so we loop through each uri.
 
@@ -256,7 +266,7 @@ def wns_send_bulk_message(
 	return res
 
 
-def dict_to_xml_schema(data):
+def dict_to_xml_schema(data: dict[str, Any]) -> ET.Element:
 	"""
 	Input a dictionary to be converted to xml. There should be only one key at
 	the top level. The value must be a dict with (required) `children` key and
@@ -322,7 +332,7 @@ def dict_to_xml_schema(data):
 		return root
 
 
-def _add_sub_elements_from_dict(parent, sub_dict):
+def _add_sub_elements_from_dict(parent: ET.Element, sub_dict: dict[str, Any]) -> None:
 	"""
 	Add SubElements to the parent element.
 
@@ -357,7 +367,7 @@ def _add_sub_elements_from_dict(parent, sub_dict):
 				sub_element.text = children
 
 
-def _add_element_attrs(elem, attrs):
+def _add_element_attrs(elem: ET.Element, attrs: dict[str, str]) -> ET.Element:
 	"""
 	Add attributes to the given element.
 

--- a/push_notifications/wns.py
+++ b/push_notifications/wns.py
@@ -170,11 +170,11 @@ def _wns_prepare_toast(data: dict[str, Any], **kwargs: Any) -> bytes:
 
 
 def wns_send_message(
-	uri: str, 
-	message: str | dict[str, list[str]] = None, 
-	xml_data: dict[str, Any] = None, 
-	raw_data: str | bytes | None= None, 
-	application_id: str | None = None, 
+	uri: str,
+	message: str | dict[str, list[str]] = None,
+	xml_data: dict[str, Any] = None,
+	raw_data: str | bytes | None= None,
+	application_id: str | None = None,
 	**kwargs: Any
 ) -> str:
 	"""
@@ -240,11 +240,11 @@ def wns_send_message(
 
 
 def wns_send_bulk_message(
-	uri_list: list[str], 
-	message: str | dict[str, list[str]] | None = None, 
-	xml_data: dict[str, Any] | None = None, 
-	raw_data: str | bytes | None = None, 
-	application_id: str | None = None, 
+	uri_list: list[str],
+	message: str | dict[str, list[str]] | None = None,
+	xml_data: dict[str, Any] | None = None,
+	raw_data: str | bytes | None = None,
+	application_id: str | None = None,
 	**kwargs: Any
 ) -> list[str]:
 	"""


### PR DESCRIPTION
* Add type anotation to methods and functions
* Use full path for imports instead of `..`
* Remove legacy Union, Optional, Dict and List in functions and methods
* Use isinstance for type check instead of using the type itself
* Replace type anotation which was using `any` with the right `Any`