### PR TITLE
Enhance README with notification message and badge examples for FCM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,6 +283,24 @@ When using FCM, ``django-push-notifications`` will automatically use the `notifi
 	# Send a notification message with additionnal payload (alternative syntax)
 	fcm_device.send_message("This is a enriched message", title="Notification title", badge=6)
 
+	# Send a silent notification message with badge - *only working with iOS*:
+    fcm_device.send_message(
+		messaging.Message(
+			apns=messaging.APNSConfig(
+				payload=messaging.APNSPayload(aps=messaging.Aps(badge=5))
+			)
+		)
+	)
+
+	# Send a notification with badge for iOS and android:
+	fcm_device.send_message(
+		messaging.Message(
+			notification=messaging.Notification(title="otification title", body="This is a enriched message"),
+		),
+		badge=6, # android
+		apns=messaging.APNSConfig(payload=messaging.APNSPayload(aps=messaging.Aps(badge=6))), # ios
+	)
+
 	# Send a notification message with extra data
 	fcm_device.send_message("This is a message with data", extra={"other": "content", "misc": "data"})
 

--- a/README.rst
+++ b/README.rst
@@ -284,7 +284,7 @@ When using FCM, ``django-push-notifications`` will automatically use the `notifi
 	fcm_device.send_message("This is a enriched message", title="Notification title", badge=6)
 
 	# Send a silent notification message with badge - *only working with iOS*:
-    fcm_device.send_message(
+	fcm_device.send_message(
 		messaging.Message(
 			apns=messaging.APNSConfig(
 				payload=messaging.APNSPayload(aps=messaging.Aps(badge=5))
@@ -296,9 +296,9 @@ When using FCM, ``django-push-notifications`` will automatically use the `notifi
 	fcm_device.send_message(
 		messaging.Message(
 			notification=messaging.Notification(title="otification title", body="This is a enriched message"),
+			apns=messaging.APNSConfig(payload=messaging.APNSPayload(aps=messaging.Aps(badge=6))), # ios
 		),
 		badge=6, # android
-		apns=messaging.APNSConfig(payload=messaging.APNSPayload(aps=messaging.Aps(badge=6))), # ios
 	)
 
 	# Send a notification message with extra data


### PR DESCRIPTION
FCM - Added examples for sending silent notifications and notifications with badges for iOS and Android.

I had quite a bit of trouble figuring out how to send notifications with badges using FCM. So the contributed code in Readme has been tested and works on my project.