### PR TITLE
Fix: omit alert key from APS payload when alert=None (silent notification)

### DIFF
--- a/push_notifications/apns_async.py
+++ b/push_notifications/apns_async.py
@@ -116,7 +116,7 @@ class Alert:
 
 def _create_notification_request_from_args(
 	registration_id: str,
-	alert: Union[str, Alert, None],
+	alert: Optional[Union[str, Alert]],
 	badge: Optional[int] = None,
 	sound: Optional[str] = None,
 	extra: Optional[Dict[str, Any]] = None,
@@ -223,7 +223,7 @@ def _get_credentials(application_id: Optional[str] = None) -> Credentials:
 
 def apns_send_message(
 	registration_id: str,
-	alert: Union[str, Alert, None],
+	alert: Optional[Union[str, Alert]],
 	application_id: Optional[str] = None,
 	creds: Optional[Credentials] = None,
 	topic: Optional[str] = None,
@@ -292,7 +292,7 @@ def apns_send_message(
 
 def apns_send_bulk_message(
 	registration_ids: list[str],
-	alert: Union[str, Alert, None],
+	alert: Optional[Union[str, Alert]],
 	application_id: Optional[str] = None,
 	creds: Optional[Credentials] = None,
 	topic: Optional[str] = None,
@@ -389,7 +389,7 @@ def apns_send_bulk_message(
 
 async def _send_bulk_request(
 	registration_ids: list[str],
-	alert: Union[str, Alert, None],
+	alert: Optional[Union[str, Alert]],
 	application_id: Optional[str] = None,
 	creds: Optional[Credentials] = None,
 	topic: Optional[str] = None,

--- a/push_notifications/apns_async.py
+++ b/push_notifications/apns_async.py
@@ -129,13 +129,13 @@ def _create_notification_request_from_args(
 	message_kwargs: Dict[str, Any] = {},
 	notification_request_kwargs: Dict[str, Any] = {},
 ) -> NotificationRequest:
-	if alert is None:
-		alert = Alert(body="")
-
 	if loc_key:
-		if isinstance(alert, str):
-			alert = Alert(body=alert)
-		alert.loc_key = loc_key
+		if alert is None:
+			alert = Alert(loc_key=loc_key)
+		else:
+			if isinstance(alert, str):
+				alert = Alert(body=alert)
+			alert.loc_key = loc_key
 
 	if isinstance(alert, Alert):
 		alert = alert.asDict()
@@ -153,16 +153,19 @@ def _create_notification_request_from_args(
 	if extra is None:
 		extra = {}
 
+	aps: Dict[str, Any] = {
+		"badge": badge,
+		"sound": sound,
+		"thread-id": thread_id,
+		**aps_kwargs,
+	}
+	if alert is not None:
+		aps["alert"] = alert
+
 	request = NotificationRequest(
 		device_token=registration_id,
 		message={
-			"aps": {
-				"alert": alert,
-				"badge": badge,
-				"sound": sound,
-				"thread-id": thread_id,
-				**aps_kwargs,
-			},
+			"aps": aps,
 			**extra,
 			**message_kwargs,
 		},

--- a/push_notifications/apns_async.py
+++ b/push_notifications/apns_async.py
@@ -116,7 +116,7 @@ class Alert:
 
 def _create_notification_request_from_args(
 	registration_id: str,
-	alert: Union[str, Alert],
+	alert: Union[str, Alert, None],
 	badge: Optional[int] = None,
 	sound: Optional[str] = None,
 	extra: Optional[Dict[str, Any]] = None,
@@ -220,7 +220,7 @@ def _get_credentials(application_id: Optional[str] = None) -> Credentials:
 
 def apns_send_message(
 	registration_id: str,
-	alert: Union[str, Alert],
+	alert: Union[str, Alert, None],
 	application_id: Optional[str] = None,
 	creds: Optional[Credentials] = None,
 	topic: Optional[str] = None,
@@ -289,7 +289,7 @@ def apns_send_message(
 
 def apns_send_bulk_message(
 	registration_ids: list[str],
-	alert: Union[str, Alert],
+	alert: Union[str, Alert, None],
 	application_id: Optional[str] = None,
 	creds: Optional[Credentials] = None,
 	topic: Optional[str] = None,
@@ -386,7 +386,7 @@ def apns_send_bulk_message(
 
 async def _send_bulk_request(
 	registration_ids: list[str],
-	alert: Union[str, Alert],
+	alert: Union[str, Alert, None],
 	application_id: Optional[str] = None,
 	creds: Optional[Credentials] = None,
 	topic: Optional[str] = None,

--- a/tests/test_apns_async_push_payload.py
+++ b/tests/test_apns_async_push_payload.py
@@ -276,3 +276,20 @@ class APNSAsyncPushPayloadTest(TestCase):
 		req = args[0]
 
 		assert "content-available" not in req.message["aps"]
+
+	@mock.patch("push_notifications.apns_async.APNs", autospec=True)
+	def test_silent_push_with_alert_none(self, mock_apns):
+		"""alert=None should omit the 'alert' key from the APS payload (silent notification)."""
+		apns_send_message(
+			"123",
+			None,
+			content_available=True,
+			creds=TokenCredentials(key="aaa", key_id="bbb", team_id="ccc"),
+		)
+
+		args, _kwargs = mock_apns.return_value.send_notification.call_args
+		req = args[0]
+
+		self.assertEqual(req.device_token, "123")
+		assert "alert" not in req.message["aps"]
+		assert req.message["aps"]["content-available"] == 1


### PR DESCRIPTION
When `alert=None` was passed to `apns_send_message()` or `apns_send_bulk_message()`,
the code silently converted it to `Alert(body="")` and still included `"alert": {"body": ""}`
in the APS payload. This made true silent notifications impossible via this API.

The docstring documented `alert=None` as the way to send silent notifications, but the
implementation did not match.